### PR TITLE
Redesign login page with minimal SaaS split-panel layout

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,35 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+HR managers, team leads, and employees at small-to-mid-sized companies. Used during the workday in bright office environments. Primary users are HR staff who sign in to manage attendance, leaves, payroll runs, and performance reviews — people who treat this as a core work tool, not an occasional utility.
+
+## Product Purpose
+
+HRMS unifies people operations: attendance tracking, leave management, payroll processing, and performance insights in one place. Success means HR teams spend less time on administrative friction and more time on decisions. The tool must feel reliable and fast, not bureaucratic.
+
+## Brand Personality
+
+Precise, dependable, unhurried. The interface should convey institutional trust without feeling corporate or stale. Three words: clear, capable, calm.
+
+## Anti-references
+
+- Overcrowded enterprise HR dashboards (Workday, SAP SuccessFactors) — too much visual noise, overwhelming navigation
+- Gradient-heavy SaaS marketing aesthetics — garish purple/blue gradients, glassmorphism decorations
+- Consumer app friendliness gone wrong — playful, bubbly, feels wrong for a tool handling salaries and legal leave records
+
+## Design Principles
+
+1. **Function first, decoration never.** Every visual element must earn its place by aiding comprehension or action.
+2. **Calm authority.** The tool handles sensitive data (salaries, attendance records). Design should project steadiness, not excitement.
+3. **One thing at a time.** Forms and flows should surface only what the current step requires. Progressive disclosure over front-loading.
+4. **Consistent density.** Match the information density to the task: tight for data tables, generous for forms and empty states.
+5. **Trust through precision.** Exact labels, no vague copy, clear error messages. Users must feel the system understands their domain.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA as the baseline. All interactive elements keyboard-navigable. Error states communicated through both color and text, never color alone. Sufficient contrast on all surfaces.

--- a/hrms-ui/src/app/features/login/login.css
+++ b/hrms-ui/src/app/features/login/login.css
@@ -1,7 +1,290 @@
+/* ===== Layout shell ===== */
+.auth-shell {
+  display: grid;
+  grid-template-columns: 400px 1fr;
+  min-height: 100vh;
+}
+
+/* ===== Brand panel (always dark) ===== */
+.brand-panel {
+  display: flex;
+  flex-direction: column;
+  background-color: oklch(18% 0.012 255);
+  padding: 44px 48px;
+  overflow: hidden;
+}
+
+.brand-top {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-mark {
+  width: 36px;
+  height: 36px;
+  background-color: oklch(26% 0.016 255);
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.brand-mark i {
+  color: oklch(78% 0.01 255);
+  font-size: 16px;
+}
+
+.brand-wordmark {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.brand-name {
+  font-size: 14px;
+  font-weight: 700;
+  color: oklch(93% 0.006 255);
+  letter-spacing: 0.07em;
+  line-height: 1;
+}
+
+.brand-tagline-small {
+  font-size: 10px;
+  color: oklch(48% 0.008 255);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+.brand-body {
+  margin-top: auto;
+  margin-bottom: auto;
+  padding: 48px 0;
+}
+
+.brand-headline {
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.28;
+  color: oklch(94% 0.005 255);
+  margin: 0 0 16px;
+  letter-spacing: -0.01em;
+}
+
+.brand-desc {
+  font-size: 13.5px;
+  line-height: 1.72;
+  color: oklch(55% 0.008 255);
+  margin: 0 0 36px;
+}
+
+.brand-features {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.brand-features li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: oklch(60% 0.008 255);
+  line-height: 1;
+}
+
+.feature-dot {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: oklch(26% 0.016 255);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.feature-dot i {
+  font-size: 9px;
+  color: oklch(66% 0.13 155);
+}
+
+.brand-foot {
+  font-size: 11.5px;
+  color: oklch(36% 0.008 255);
+}
+
+/* ===== Form panel ===== */
+.form-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 32px;
+  background-color: oklch(98.5% 0.004 88);
+}
+
+:where([data-theme=dark]) .form-panel {
+  background-color: oklch(13% 0.01 255);
+}
+
+.form-inner {
+  width: 100%;
+  max-width: 368px;
+}
+
+/* ===== Form header ===== */
+.form-head {
+  margin-bottom: 32px;
+}
+
+.form-title {
+  font-size: 21px;
+  font-weight: 700;
+  color: oklch(20% 0.01 255);
+  margin: 0 0 8px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+:where([data-theme=dark]) .form-title {
+  color: oklch(92% 0.006 255);
+}
+
+.form-subtitle {
+  font-size: 13.5px;
+  color: oklch(50% 0.008 255);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ===== Auth form ===== */
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: oklch(26% 0.01 255);
+  line-height: 1;
+}
+
+:where([data-theme=dark]) .field-label {
+  color: oklch(80% 0.008 255);
+}
+
+.label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.soft-link {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: oklch(48% 0.14 255);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.15s ease-out;
+}
+
+.soft-link:hover {
+  color: oklch(36% 0.17 255);
+}
+
+.field-error {
+  font-size: 12px;
+  color: oklch(46% 0.18 25);
+  display: block;
+}
+
+/* ===== Checkbox row ===== */
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: -4px;
+}
+
+.checkbox-label {
+  font-size: 13px;
+  color: oklch(44% 0.008 255);
+  cursor: pointer;
+  user-select: none;
+}
+
+/* ===== Error notice (no side-stripe) ===== */
+.error-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  background-color: oklch(97.5% 0.018 25);
+  border: 1px solid oklch(89% 0.055 25);
+  border-radius: 8px;
+  font-size: 13px;
+  color: oklch(40% 0.18 25);
+  line-height: 1.5;
+}
+
+.error-notice i {
+  flex-shrink: 0;
+  font-size: 13px;
+  margin-top: 1px;
+}
+
+/* ===== Hint text ===== */
+.hint-text {
+  font-size: 13px;
+  color: oklch(50% 0.008 255);
+  margin: 0;
+  line-height: 1.65;
+}
+
+/* ===== Button pair (back + action) ===== */
+.button-pair {
+  display: flex;
+  gap: 10px;
+}
+
+/* ===== Password hints popover ===== */
+.pw-hints {
+  padding: 4px 10px 10px;
+}
+
+.pw-hints p {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--p-text-color);
+  margin: 0 0 8px;
+}
+
+.pw-hints ul {
+  margin: 0;
+  padding-left: 16px;
+  font-size: 12px;
+  color: var(--p-text-muted-color);
+  line-height: 1.9;
+}
+
+/* ===== Fade-in ===== */
 @keyframes fadein {
   from {
     opacity: 0;
-    transform: translateY(-4px);
+    transform: translateY(-3px);
   }
   to {
     opacity: 1;
@@ -10,62 +293,20 @@
 }
 
 .animate-fadein {
-  animation: fadein 0.3s ease-out;
+  animation: fadein 0.22s ease-out;
 }
 
-/* ===== Login Container ===== */
-.login-container {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  position: relative;
-  overflow: hidden;
-}
-
-.login-container::before {
-  content: '';
-  position: absolute;
-  top: -50%;
-  left: -50%;
-  width: 200%;
-  height: 200%;
-  background: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.1) 0%,
-    transparent 70%
-  );
-  animation: rotate 30s linear infinite;
-}
-
-.login-container::after {
-  content: '';
-  position: absolute;
-  bottom: -50%;
-  right: -50%;
-  width: 200%;
-  height: 200%;
-  background: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.05) 0%,
-    transparent 70%
-  );
-  animation: rotate 40s linear infinite reverse;
-}
-
-@keyframes rotate {
-  from {
-    transform: rotate(0deg);
+/* ===== Responsive: hide brand panel on small screens ===== */
+@media (max-width: 720px) {
+  .auth-shell {
+    grid-template-columns: 1fr;
   }
-  to {
-    transform: rotate(360deg);
-  }
-}
 
-/* Ensure card is above background */
-.login-container p-card {
-  position: relative;
-  z-index: 10;
+  .brand-panel {
+    display: none;
+  }
+
+  .form-panel {
+    padding: 40px 24px;
+  }
 }

--- a/hrms-ui/src/app/features/login/login.html
+++ b/hrms-ui/src/app/features/login/login.html
@@ -1,368 +1,252 @@
-<div class="login-container">
-  <p-card
-    [style]="{ 'max-width': '480px', width: '100%' }"
-    styleClass="shadow-2xl border-0 overflow-hidden"
-  >
-    <ng-template #header>
-      <div
-        class="relative px-8 pt-8 pb-6 bg-gradient-to-br from-primary-500 via-primary-600 to-primary-700 dark:from-primary-600 dark:via-primary-700 dark:to-primary-800 overflow-hidden"
-      >
-        <!-- Decorative background elements -->
-        <div
-          class="absolute top-0 right-0 w-64 h-64 bg-white/5 rounded-full -mr-32 -mt-32 blur-3xl"
-        ></div>
-        <div
-          class="absolute bottom-0 left-0 w-48 h-48 bg-white/5 rounded-full -ml-24 -mb-24 blur-2xl"
-        ></div>
+<div class="auth-shell">
 
-        <div class="relative z-10">
-          <div class="flex items-center justify-center mb-4">
-            <div
-              class="w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center shadow-lg border border-white/20"
-            >
-              <i class="pi pi-building text-4xl text-white"></i>
-            </div>
+  <!-- Brand panel -->
+  <aside class="brand-panel">
+    <div class="brand-top">
+      <div class="brand-mark">
+        <i class="pi pi-building"></i>
+      </div>
+      <div class="brand-wordmark">
+        <span class="brand-name">HRMS</span>
+        <span class="brand-tagline-small">Workspace</span>
+      </div>
+    </div>
+
+    <div class="brand-body">
+      <h2 class="brand-headline">People operations,<br>made effortless.</h2>
+      <p class="brand-desc">Everything your team needs — attendance, leaves, payroll, and performance — in one place.</p>
+      <ul class="brand-features">
+        <li>
+          <span class="feature-dot"><i class="pi pi-check"></i></span>
+          Smart attendance tracking
+        </li>
+        <li>
+          <span class="feature-dot"><i class="pi pi-check"></i></span>
+          Automated payroll processing
+        </li>
+        <li>
+          <span class="feature-dot"><i class="pi pi-check"></i></span>
+          Real-time performance insights
+        </li>
+      </ul>
+    </div>
+
+    <footer class="brand-foot">© 2026 HRMS</footer>
+  </aside>
+
+  <!-- Form panel -->
+  <main class="form-panel">
+    <div class="form-inner">
+
+      <header class="form-head">
+        <h1 class="form-title">
+          @if(isForwordPassword && tempToken) { Reset password }
+          @else if(isForwordPassword) { Forgot password }
+          @else { Welcome back }
+        </h1>
+        <p class="form-subtitle">
+          @if(isForwordPassword && tempToken) { Enter your new password below. }
+          @else if(isForwordPassword) { Enter your email and we'll send a reset link. }
+          @else { Sign in to your workspace to continue. }
+        </p>
+      </header>
+
+      <!-- Sign in form -->
+      @if(!isForwordPassword) {
+      <form class="auth-form" [formGroup]="loginForm" (ngSubmit)="onSubmit()">
+
+        <div class="field-group">
+          <label for="email_input" class="field-label">Email address</label>
+          <input
+            pInputText
+            id="email_input"
+            formControlName="username"
+            autocomplete="email"
+            placeholder="you@company.com"
+            class="w-full"
+          />
+          <ng-template [formError]="'username'" let-control>
+            @if(control.errors?.['required']) {
+            <small class="field-error animate-fadein">Email is required</small>
+            }
+            @if(control.errors?.['email']) {
+            <small class="field-error animate-fadein">Enter a valid email address</small>
+            }
+          </ng-template>
+        </div>
+
+        <div class="field-group">
+          <div class="label-row">
+            <label for="password_input" class="field-label">Password</label>
+            <a class="soft-link" (click)="onForgotPasswordClick()">Forgot password?</a>
           </div>
-          <h1 class="text-3xl font-bold text-center text-white mb-2">
-            {{
-              isForwordPassword
-                ? tempToken
-                  ? 'Reset Password'
-                  : 'Forgot Password'
-                : 'Welcome Back'
-            }}
-          </h1>
-          <p class="text-center text-white/80 text-sm">
-            {{
-            isForwordPassword
-              ? tempToken
-                ? 'Enter your new password below'
-                : `We'll send you a reset link`
-              : 'Sign in to continue to your account'
-            }}
-          </p>
-        </div>
-      </div>
-    </ng-template>
-
-    <!-- Login Form -->
-    @if(!isForwordPassword) {
-    <form
-      class="flex flex-col gap-6 p-8"
-      [formGroup]="loginForm"
-      (ngSubmit)="onSubmit()"
-    >
-      <div class="flex flex-col gap-2">
-        <label
-          for="email_input"
-          class="text-surface-900 dark:text-surface-0 font-semibold text-sm flex items-center gap-2"
-        >
-          <i class="pi pi-envelope text-surface-500"></i>
-          Email Address
-        </label>
-        <input
-          pInputText
-          id="email_input"
-          formControlName="username"
-          autocomplete="email"
-          placeholder="your.email@company.com"
-          class="w-full transition-all duration-200 focus:shadow-lg"
-        />
-        <ng-template [formError]="'username'" let-control>
-          @if(control.errors?.['required']) {
-          <small class="text-red-500 flex items-center gap-1 animate-fadein">
-            <i class="pi pi-exclamation-circle"></i>Email is required
-          </small>
-          } @if(control.errors?.['email']) {
-          <small class="text-red-500 flex items-center gap-1 animate-fadein">
-            <i class="pi pi-exclamation-circle"></i>Please enter a valid email
-          </small>
-          }
-        </ng-template>
-      </div>
-
-      <div class="flex flex-col gap-2">
-        <label
-          for="password_input"
-          class="text-surface-900 dark:text-surface-0 font-semibold text-sm flex items-center gap-2"
-        >
-          <i class="pi pi-lock text-surface-500"></i>
-          Password
-        </label>
-        <p-password
-          [toggleMask]="true"
-          formControlName="password"
-          inputId="password_input"
-          placeholder="Enter your password"
-          [feedback]="false"
-          styleClass="w-full"
-          inputStyleClass="w-full transition-all duration-200 focus:shadow-lg"
-        />
-        <ng-template [formError]="'password'" let-control>
-          <small class="text-red-500 flex items-center gap-1 animate-fadein">
-            <i class="pi pi-exclamation-circle"></i>Password is required
-          </small>
-        </ng-template>
-      </div>
-
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-2">
-          <p-checkbox
-            formControlName="remember"
-            [binary]="true"
-            inputId="remember_checkbox"
-          ></p-checkbox>
-          <label
-            for="remember_checkbox"
-            class="text-surface-700 dark:text-surface-300 text-sm cursor-pointer hover:text-surface-900 dark:hover:text-surface-100 transition-colors"
-          >
-            Remember me
-          </label>
+          <p-password
+            [toggleMask]="true"
+            formControlName="password"
+            inputId="password_input"
+            placeholder="Enter your password"
+            [feedback]="false"
+            styleClass="w-full"
+            inputStyleClass="w-full"
+          />
+          <ng-template [formError]="'password'" let-control>
+            <small class="field-error animate-fadein">Password is required</small>
+          </ng-template>
         </div>
 
-        <a
-          class="text-primary hover:text-primary-700 dark:hover:text-primary-400 cursor-pointer text-sm font-semibold transition-all hover:underline"
-          (click)="onForgotPasswordClick()"
-        >
-          Forgot Password?
-        </a>
-      </div>
-
-      @if(error) {
-      <div
-        class="p-4 bg-red-50 dark:bg-red-900/20 border-l-4 border-red-500 rounded-lg animate-fadein"
-      >
-        <div class="flex items-start gap-3">
-          <i
-            class="pi pi-times-circle text-red-600 dark:text-red-400 text-lg mt-0.5"
-          ></i>
-          <span class="text-red-700 dark:text-red-300 text-sm font-medium">{{
-            error
-          }}</span>
+        <div class="checkbox-row">
+          <p-checkbox formControlName="remember" [binary]="true" inputId="remember_cb"></p-checkbox>
+          <label for="remember_cb" class="checkbox-label">Keep me signed in</label>
         </div>
-      </div>
-      }
 
-      <button
-        pButton
-        type="submit"
-        label="Sign In"
-        icon="pi pi-sign-in"
-        iconPos="right"
-        [disabled]="!loginForm.valid || isLoading"
-        [loading]="isLoading"
-        class="w-full h-12 font-semibold text-base shadow-lg hover:shadow-xl transition-all duration-200 hover:-translate-y-0.5"
-        styleClass="w-full justify-center"
-      ></button>
-    </form>
-    }
-
-    <!-- Forgot Password Form -->
-    @else if(isForwordPassword && !tempToken) {
-    <form
-      class="flex flex-col gap-6 p-8"
-      [formGroup]="forgotPasswordForm"
-      (ngSubmit)="onForgotPassword()"
-    >
-      <div class="flex flex-col gap-2">
-        <label
-          for="forgot_email"
-          class="text-surface-900 dark:text-surface-0 font-semibold text-sm flex items-center gap-2"
-        >
-          <i class="pi pi-envelope text-surface-500"></i>
-          Email Address
-        </label>
-        <input
-          pInputText
-          id="forgot_email"
-          formControlName="username"
-          autocomplete="email"
-          placeholder="your.email@company.com"
-          class="w-full transition-all duration-200 focus:shadow-lg"
-        />
-        <ng-template [formError]="'username'" let-control>
-          @if(control.errors?.['required']) {
-          <small class="text-red-500 flex items-center gap-1 animate-fadein">
-            <i class="pi pi-exclamation-circle"></i>Email is required
-          </small>
-          } @if(control.errors?.['email']) {
-          <small class="text-red-500 flex items-center gap-1 animate-fadein">
-            <i class="pi pi-exclamation-circle"></i>Please enter a valid email
-          </small>
-          }
-        </ng-template>
-      </div>
-
-      <div
-        class="p-4 bg-blue-50 dark:bg-blue-900/20 border-l-4 border-primary rounded-lg"
-      >
-        <div class="flex gap-3">
-          <i class="pi pi-info-circle text-primary text-lg mt-0.5"></i>
-          <span class="text-blue-700 dark:text-blue-300 text-sm">
-            A password reset link will be sent to your registered email address.
-            Please check your inbox and spam folder.
-          </span>
+        @if(error) {
+        <div class="error-notice animate-fadein">
+          <i class="pi pi-exclamation-triangle"></i>
+          <span>{{ error }}</span>
         </div>
-      </div>
+        }
 
-      @if(error) {
-      <div
-        class="p-4 bg-red-50 dark:bg-red-900/20 border-l-4 border-red-500 rounded-lg animate-fadein"
-      >
-        <div class="flex items-start gap-3">
-          <i
-            class="pi pi-times-circle text-red-600 dark:text-red-400 text-lg mt-0.5"
-          ></i>
-          <span class="text-red-700 dark:text-red-300 text-sm font-medium">{{
-            error
-          }}</span>
-        </div>
-      </div>
-      }
-
-      <div class="flex gap-3">
-        <button
-          pButton
-          type="button"
-          label="Back to Login"
-          icon="pi pi-arrow-left"
-          severity="secondary"
-          [outlined]="true"
-          (click)="isForwordPassword = !isForwordPassword"
-          class="flex-1 h-12 font-semibold transition-all duration-200 hover:-translate-y-0.5"
-        ></button>
         <button
           pButton
           type="submit"
-          label="Send Reset Link"
-          icon="pi pi-send"
-          iconPos="right"
-          [disabled]="!forgotPasswordForm.valid || isLoading"
+          label="Sign in"
+          [disabled]="!loginForm.valid || isLoading"
           [loading]="isLoading"
-          class="flex-1 h-12 font-semibold shadow-lg hover:shadow-xl transition-all duration-200 hover:-translate-y-0.5"
+          styleClass="w-full justify-center"
         ></button>
-      </div>
-    </form>
-    }
 
-    <!-- Change Password Form -->
-    @else if(isForwordPassword && tempToken) {
-    <form
-      class="flex flex-col gap-6 p-8"
-      [formGroup]="changePasswordForm"
-      (ngSubmit)="onChangePassword()"
-    >
-      <div class="flex flex-col gap-2">
-        <label
-          for="new_password"
-          class="text-surface-900 dark:text-surface-0 font-semibold text-sm flex items-center gap-2"
-        >
-          <i class="pi pi-lock text-surface-500"></i>
-          New Password
-        </label>
-        <p-password
-          [toggleMask]="true"
-          formControlName="newPassword"
-          inputId="new_password"
-          placeholder="Create a strong password"
-          styleClass="w-full"
-          inputStyleClass="w-full transition-all duration-200 focus:shadow-lg"
-        >
-          <ng-template #footer>
-            <p-divider />
-            <div class="px-3 pb-2">
-              <p
-                class="font-bold text-surface-900 dark:text-surface-0 mb-3 text-sm flex items-center gap-2"
-              >
-                <i class="pi pi-shield text-primary"></i>
-                Password Requirements:
-              </p>
-              <ul
-                class="pl-5 my-0 space-y-2 text-sm text-surface-600 dark:text-surface-400"
-              >
-                <li class="flex items-center gap-2">
-                  <i class="pi pi-check-circle text-green-500 text-xs"></i>
-                  At least one lowercase letter
-                </li>
-                <li class="flex items-center gap-2">
-                  <i class="pi pi-check-circle text-green-500 text-xs"></i>
-                  At least one uppercase letter
-                </li>
-                <li class="flex items-center gap-2">
-                  <i class="pi pi-check-circle text-green-500 text-xs"></i>
-                  At least one number
-                </li>
-                <li class="flex items-center gap-2">
-                  <i class="pi pi-check-circle text-green-500 text-xs"></i>
-                  Minimum 8 characters
-                </li>
-              </ul>
-            </div>
-          </ng-template>
-        </p-password>
-        <ng-template [formError]="'newPassword'" let-control>
-          @if(control.errors?.['passwordStrength']) {
-          <small class="text-red-500 flex items-center gap-1 animate-fadein">
-            <i class="pi pi-exclamation-circle"></i>Password does not meet
-            requirements
-          </small>
-          }
-        </ng-template>
-      </div>
-
-      <div class="flex flex-col gap-2">
-        <label
-          for="confirm_password"
-          class="text-surface-900 dark:text-surface-0 font-semibold text-sm flex items-center gap-2"
-        >
-          <i class="pi pi-lock text-surface-500"></i>
-          Confirm Password
-        </label>
-        <p-password
-          [toggleMask]="true"
-          [feedback]="false"
-          formControlName="confirmPassword"
-          inputId="confirm_password"
-          placeholder="Re-enter your password"
-          styleClass="w-full"
-          inputStyleClass="w-full transition-all duration-200 focus:shadow-lg"
-        />
-        <ng-template [formError]="'confirmPassword'" let-control>
-          @if(control.errors?.['passwordMismatch']) {
-          <small class="text-red-500 flex items-center gap-1 animate-fadein">
-            <i class="pi pi-exclamation-circle"></i>Passwords do not match
-          </small>
-          }
-        </ng-template>
-      </div>
-
-      @if(error) {
-      <div
-        class="p-4 bg-red-50 dark:bg-red-900/20 border-l-4 border-red-500 rounded-lg animate-fadein"
-      >
-        <div class="flex items-start gap-3">
-          <i
-            class="pi pi-times-circle text-red-600 dark:text-red-400 text-lg mt-0.5"
-          ></i>
-          <span class="text-red-700 dark:text-red-300 text-sm font-medium">{{
-            error
-          }}</span>
-        </div>
-      </div>
+      </form>
       }
 
-      <button
-        pButton
-        type="submit"
-        label="Reset Password"
-        icon="pi pi-check"
-        iconPos="right"
-        [disabled]="!changePasswordForm.valid || isLoading"
-        [loading]="isLoading"
-        class="w-full h-12 font-semibold text-base shadow-lg hover:shadow-xl transition-all duration-200 hover:-translate-y-0.5"
-        styleClass="w-full justify-center"
-      ></button>
-    </form>
-    }
-  </p-card>
+      <!-- Forgot password form -->
+      @else if(isForwordPassword && !tempToken) {
+      <form class="auth-form" [formGroup]="forgotPasswordForm" (ngSubmit)="onForgotPassword()">
+
+        <div class="field-group">
+          <label for="forgot_email" class="field-label">Email address</label>
+          <input
+            pInputText
+            id="forgot_email"
+            formControlName="username"
+            autocomplete="email"
+            placeholder="you@company.com"
+            class="w-full"
+          />
+          <ng-template [formError]="'username'" let-control>
+            @if(control.errors?.['required']) {
+            <small class="field-error animate-fadein">Email is required</small>
+            }
+            @if(control.errors?.['email']) {
+            <small class="field-error animate-fadein">Enter a valid email address</small>
+            }
+          </ng-template>
+        </div>
+
+        <p class="hint-text">
+          We'll send a reset link to this address if an account exists.
+        </p>
+
+        @if(error) {
+        <div class="error-notice animate-fadein">
+          <i class="pi pi-exclamation-triangle"></i>
+          <span>{{ error }}</span>
+        </div>
+        }
+
+        <div class="button-pair">
+          <button
+            pButton
+            type="button"
+            label="Back"
+            severity="secondary"
+            [outlined]="true"
+            (click)="isForwordPassword = !isForwordPassword"
+          ></button>
+          <button
+            pButton
+            type="submit"
+            label="Send reset link"
+            [disabled]="!forgotPasswordForm.valid || isLoading"
+            [loading]="isLoading"
+            style="flex: 1"
+          ></button>
+        </div>
+
+      </form>
+      }
+
+      <!-- Reset password form -->
+      @else if(isForwordPassword && tempToken) {
+      <form class="auth-form" [formGroup]="changePasswordForm" (ngSubmit)="onChangePassword()">
+
+        <div class="field-group">
+          <label for="new_password" class="field-label">New password</label>
+          <p-password
+            [toggleMask]="true"
+            formControlName="newPassword"
+            inputId="new_password"
+            placeholder="Create a strong password"
+            styleClass="w-full"
+            inputStyleClass="w-full"
+          >
+            <ng-template #footer>
+              <p-divider />
+              <div class="pw-hints">
+                <p>Requirements</p>
+                <ul>
+                  <li>At least one lowercase letter</li>
+                  <li>At least one uppercase letter</li>
+                  <li>At least one number</li>
+                  <li>Minimum 8 characters</li>
+                </ul>
+              </div>
+            </ng-template>
+          </p-password>
+          <ng-template [formError]="'newPassword'" let-control>
+            @if(control.errors?.['passwordStrength']) {
+            <small class="field-error animate-fadein">Password does not meet requirements</small>
+            }
+          </ng-template>
+        </div>
+
+        <div class="field-group">
+          <label for="confirm_password" class="field-label">Confirm password</label>
+          <p-password
+            [toggleMask]="true"
+            [feedback]="false"
+            formControlName="confirmPassword"
+            inputId="confirm_password"
+            placeholder="Re-enter your password"
+            styleClass="w-full"
+            inputStyleClass="w-full"
+          />
+          <ng-template [formError]="'confirmPassword'" let-control>
+            @if(control.errors?.['passwordMismatch']) {
+            <small class="field-error animate-fadein">Passwords do not match</small>
+            }
+          </ng-template>
+        </div>
+
+        @if(error) {
+        <div class="error-notice animate-fadein">
+          <i class="pi pi-exclamation-triangle"></i>
+          <span>{{ error }}</span>
+        </div>
+        }
+
+        <button
+          pButton
+          type="submit"
+          label="Reset password"
+          [disabled]="!changePasswordForm.valid || isLoading"
+          [loading]="isLoading"
+          styleClass="w-full justify-center"
+        ></button>
+
+      </form>
+      }
+
+    </div>
+  </main>
+
 </div>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the purple gradient background and glassmorphism card header with a clean two-panel layout: fixed dark brand sidebar + light form panel
- Removes all side-stripe borders (`border-left-4` alerts), decorative blur circles, and gradient overlays throughout the login flow
- Error states now use full-border boxes with background tints instead of left-stripe callouts
- Typography hierarchy tightened: weight-contrast labels, a single soft link for "Forgot password?", generous field spacing
- Brand panel is always dark (oklch deep slate); form panel uses a barely-warm off-white; both panels handle dark mode via `[data-theme=dark]`
- Brand panel hidden on screens ≤720px, form panel becomes full-width
- Adds `PRODUCT.md` to establish design context for future impeccable UI passes

## Test plan

- [ ] Sign in flow: email + password, valid/invalid states, error banner displays correctly
- [ ] "Forgot password?" link toggles to forgot-password form and back
- [ ] Forgot password form: submit shows hint text, error banner on failure
- [ ] Reset password form (with tempToken): password strength popup, mismatch error
- [ ] "Remember me" checkbox pre-fills email on next load
- [ ] Responsive: at ≤720px brand panel hides, form fills the screen
- [ ] Dark mode: form panel switches to dark surface, labels and errors remain legible

https://claude.ai/code/session_01GpxmZMYsaqWN1MymDhyg8f
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpxmZMYsaqWN1MymDhyg8f)_