### PR TITLE
Redesign layout shell and dashboard UI

### DIFF
--- a/hrms-ui/src/app/features/layout/dashboard/dashboard.css
+++ b/hrms-ui/src/app/features/layout/dashboard/dashboard.css
@@ -1,190 +1,230 @@
-.card-icons {
-  font-size: 1.5rem;
+/* Page */
+.dash-page {
+  max-width: 1280px;
 }
 
-.p-card {
-  padding: 20px;
+/* Page header */
+.page-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--p-text-color);
+  letter-spacing: -0.01em;
 }
 
-/* ===== Dashboard Metric Cards ===== */
-.metric-card {
-  position: relative;
-  overflow: hidden;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+.page-date {
+  font-size: 0.8125rem;
+  color: var(--p-text-muted-color);
+  margin-top: 2px;
 }
 
-.metric-card::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 100px;
-  height: 100px;
-  background: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.2) 0%,
-    transparent 70%
-  );
-  border-radius: 50%;
-  transform: translate(30%, -30%);
+.clock-status-label {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--p-text-muted-color);
 }
 
-.metric-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+.clock-status-value {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--p-text-color);
+  margin-top: 1px;
 }
 
-.metric-card.gradient-blue {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: white;
+/* Stat strip */
+.stat-cell {
+  background: var(--p-surface-0);
+  border: 1px solid var(--p-surface-200);
+  border-radius: 10px;
+  padding: 18px 20px;
 }
 
-.metric-card.gradient-green {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
-  color: white;
-}
-
-.metric-card.gradient-orange {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-  color: white;
-}
-
-.metric-card.gradient-purple {
-  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
-  color: white;
-}
-
-/* Animated Counter */
-.counter-number {
-  font-size: 2.5rem;
-  font-weight: 700;
-  line-height: 1;
-  animation: countUp 0.8s ease-out;
-}
-
-@keyframes countUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Icon Badge */
-.icon-badge {
-  width: 56px;
-  height: 56px;
-  border-radius: 16px;
+.stat-header {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 24px;
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(10px);
-  transition: all 0.3s ease;
+  justify-content: space-between;
+  margin-bottom: 10px;
 }
 
-.metric-card:hover .icon-badge {
-  transform: rotate(10deg) scale(1.1);
-}
-
-/* Chart Container */
-.chart-container {
-  background: var(--p-surface-0);
-  border-radius: 16px;
-  padding: 24px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  transition: all 0.3s ease;
-}
-
-.chart-container:hover {
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
-}
-
-/* Quick Action Cards */
-.quick-action-card {
-  position: relative;
-  padding: 20px;
-  border-radius: 12px;
-  border: 2px solid var(--p-surface-200);
-  background: var(--p-surface-0);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  cursor: pointer;
-}
-
-.quick-action-card:hover {
-  border-color: var(--p-primary-500);
-  background: var(--p-primary-50);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-}
-
-.quick-action-card i {
-  transition: all 0.3s ease;
-}
-
-.quick-action-card:hover i {
-  transform: scale(1.2);
-  color: var(--p-primary-600);
-}
-
-/* Welcome Section */
-.welcome-header {
-  background: linear-gradient(
-    135deg,
-    var(--p-primary-50) 0%,
-    var(--p-primary-100) 100%
-  );
-  border-radius: 16px;
-  padding: 32px;
-  margin-bottom: 24px;
-  position: relative;
-  overflow: hidden;
-}
-
-.welcome-header::before {
-  content: '';
-  position: absolute;
-  top: -50%;
-  right: -10%;
-  width: 300px;
-  height: 300px;
-  background: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.3) 0%,
-    transparent 70%
-  );
-  border-radius: 50%;
-}
-
-/* Status Indicator */
-.status-indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  border-radius: 20px;
-  font-size: 0.875rem;
+.stat-label {
+  font-size: 0.6875rem;
   font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--p-text-muted-color);
 }
 
-.status-indicator.present {
-  background: #d1fae5;
-  color: #065f46;
+.stat-icon {
+  font-size: 0.875rem;
+  color: var(--p-surface-400);
 }
 
-.status-indicator.absent {
-  background: #fee2e2;
-  color: #991b1b;
+.stat-value {
+  font-size: 1.875rem;
+  font-weight: 600;
+  color: var(--p-text-color);
+  line-height: 1;
+  letter-spacing: -0.02em;
 }
 
-.status-indicator.on-leave {
-  background: #fef3c7;
-  color: #92400e;
+.stat-unit {
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--p-text-muted-color);
+  letter-spacing: 0;
 }
-.p-card {
+
+/* Panels */
+.panel {
+  background: var(--p-surface-0);
+  border: 1px solid var(--p-surface-200);
+  border-radius: 10px;
   padding: 20px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--p-surface-100);
+}
+
+.panel-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--p-text-color);
+  letter-spacing: -0.01em;
+}
+
+.panel-subtitle {
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+  margin-top: 2px;
+}
+
+/* Data table */
+.data-table {
+  border-collapse: collapse;
+}
+
+.data-table th {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--p-text-muted-color);
+  padding: 0 12px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--p-surface-200);
+}
+
+.data-table td {
+  font-size: 0.8125rem;
+  color: var(--p-text-color);
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--p-surface-100);
+}
+
+.data-table td:not(:first-child) {
+  color: var(--p-text-muted-color);
+}
+
+.data-table tr:last-child td {
+  border-bottom: none;
+}
+
+/* Leaves */
+.leave-item {
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--p-surface-50);
+  border: 1px solid var(--p-surface-100);
+}
+
+.leave-title {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--p-text-color);
+  line-height: 1.3;
+}
+
+.leave-date {
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+  margin-top: 3px;
+}
+
+.leave-away {
+  font-size: 0.7rem;
+  color: var(--p-text-muted-color);
+  margin-top: 1px;
+}
+
+.leave-empty {
+  font-size: 0.8125rem;
+  color: var(--p-text-muted-color);
+  padding: 16px 0;
+  text-align: center;
+}
+
+/* Tasks */
+.task-item {
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--p-surface-50);
+  border: 1px solid var(--p-surface-100);
+}
+
+.task-title {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--p-text-color);
+  line-height: 1.3;
+}
+
+.task-due {
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+  margin-top: 2px;
+}
+
+/* Goals */
+.goal-title {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--p-text-color);
+}
+
+.goal-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--p-text-muted-color);
+}
+
+/* Quick actions */
+.quick-action {
+  background: var(--p-surface-50);
+  border: 1px solid var(--p-surface-200);
+  border-radius: 8px;
+  color: var(--p-text-color);
+  cursor: pointer;
+  transition: background-color 150ms ease-out, border-color 150ms ease-out;
+}
+
+.quick-action:hover {
+  background: var(--p-surface-100);
+  border-color: var(--p-surface-300);
+}
+
+.quick-action-icon {
+  font-size: 1rem;
+  color: var(--p-primary-500);
+  flex-shrink: 0;
+}
+
+.quick-action-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
 }

--- a/hrms-ui/src/app/features/layout/dashboard/dashboard.html
+++ b/hrms-ui/src/app/features/layout/dashboard/dashboard.html
@@ -1,381 +1,273 @@
-<div class="space-y-6">
-  <!-- Header -->
-  <div class="welcome-header">
-    <h1 class="text-4xl text-gray-900 font-bold relative z-10">
-      Welcome Back, {{ userInfo.name }}!
-    </h1>
-    <p class="text-gray-700 mt-2 relative z-10 flex items-center gap-2">
-      <i class="pi pi-calendar"></i>
-      {{ currentDate | date : 'fullDate' }}
-    </p>
-  </div>
+<div class="dash-page">
 
-  <!-- Today's Status -->
-  <p-card class="bg-blue-50 border border-blue-200">
-    <div class="flex items-center justify-between">
-      <div>
-        <h3 class="text-lg text-gray-900">Today's Attendance</h3>
-        <div class="flex items-center gap-2 mt-2">
-          <i class="pi pi-clock"></i>
-          <span class="text-gray-700">
-            {{
-              todayStatus === 'PRESENT'
-                ? 'Checked in at ' + todayCheckInTime
-                : todayStatus
-            }}
-          </span>
-        </div>
-        <p class="text-sm text-gray-600 mt-1">
-          Working hours: {{ todayWorkHours }}
+  <!-- Page header -->
+  <div class="page-head flex items-start justify-between gap-4 mb-8">
+    <div>
+      <h1 class="page-title">Good morning, {{ userInfo.name?.split(' ')[0] }}</h1>
+      <p class="page-date">{{ currentDate | date: 'EEEE, MMMM d, y' }}</p>
+    </div>
+    <div class="clock-action flex items-center gap-4">
+      <div class="text-right" *ngIf="todayStatus && todayStatus !== '-'">
+        <p class="clock-status-label">Today</p>
+        <p class="clock-status-value">
+          {{ todayStatus === 'PRESENT' ? 'In since ' + todayCheckInTime : todayStatus }}
         </p>
       </div>
       <p-button
-        [label]="
-          attendenceSummary?.today?.isCheckedIn ? 'Check Out' : 'Clock In'
-        "
-        icon="pi pi-clock"
-        (click)="clockInOut()"
-      >
+        [label]="attendenceSummary?.today?.isCheckedIn ? 'Clock Out' : 'Clock In'"
+        [icon]="attendenceSummary?.today?.isCheckedIn ? 'pi pi-stop-circle' : 'pi pi-play-circle'"
+        size="small"
+        (click)="clockInOut()">
       </p-button>
     </div>
-  </p-card>
+  </div>
 
-  <!-- Metrics Grid -->
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-    <!-- ADMIN VIEW -->
+  <!-- Stat strip -->
+  <div class="stat-grid grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+
+    <!-- ADMIN -->
     <ng-container *ngIf="userInfo.role === 'ADMIN'">
-      <div class="metric-card gradient-blue rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Total Employees</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.totalEmployees || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-users text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Total Employees</span>
+          <i class="pi pi-users stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.totalEmployees || 0 }}</p>
       </div>
-      <div class="metric-card gradient-green rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Total Departments</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.totalDepartments || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-building text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Departments</span>
+          <i class="pi pi-sitemap stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.totalDepartments || 0 }}</p>
       </div>
-      <div class="metric-card gradient-orange rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Pending Leaves</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.pendingLeaves || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-exclamation-circle text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Pending Leaves</span>
+          <i class="pi pi-calendar-times stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.pendingLeaves || 0 }}</p>
       </div>
-      <div class="metric-card gradient-blue rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Present Today</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.todayAttendance || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-clock text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Present Today</span>
+          <i class="pi pi-check-circle stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.todayAttendance || 0 }}</p>
       </div>
     </ng-container>
 
-    <!-- HR VIEW -->
+    <!-- HR -->
     <ng-container *ngIf="userInfo.role === 'HR'">
-      <div class="metric-card gradient-blue rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Total Employees</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.totalEmployees || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-users text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Total Employees</span>
+          <i class="pi pi-users stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.totalEmployees || 0 }}</p>
       </div>
-      <div class="metric-card gradient-orange rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Pending Leaves</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.pendingLeaves || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-exclamation-circle text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Pending Leaves</span>
+          <i class="pi pi-calendar-times stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.pendingLeaves || 0 }}</p>
       </div>
-      <div class="metric-card gradient-green rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Today's Attendance</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.todayAttendance || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-clock text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Attendance Today</span>
+          <i class="pi pi-check-circle stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.todayAttendance || 0 }}</p>
       </div>
-      <div class="metric-card gradient-blue rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Pending Payrolls</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.pendingPayrolls || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-dollar text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Pending Payrolls</span>
+          <i class="pi pi-dollar stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.pendingPayrolls || 0 }}</p>
       </div>
     </ng-container>
 
-    <!-- MANAGER VIEW -->
+    <!-- MANAGER -->
     <ng-container *ngIf="userInfo.role === 'MANAGER'">
-      <div class="metric-card gradient-blue rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Team Size</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.teamSize || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-users text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Team Size</span>
+          <i class="pi pi-users stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.teamSize || 0 }}</p>
       </div>
-      <div class="metric-card gradient-orange rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Team Pending Leaves</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.teamLeaves || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-exclamation-circle text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Pending Leaves</span>
+          <i class="pi pi-calendar-times stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.teamLeaves || 0 }}</p>
       </div>
-      <div class="metric-card gradient-green rounded-2xl p-6 shadow-medium">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-white/80 font-medium">Team Attendance Today</p>
-            <p class="counter-number mt-2">{{ dashboardStats?.teamAttendance || 0 }}</p>
-          </div>
-          <div class="icon-badge"><i class="pi pi-clock text-white"></i></div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Present Today</span>
+          <i class="pi pi-check-circle stat-icon"></i>
         </div>
+        <p class="stat-value">{{ dashboardStats?.teamAttendance || 0 }}</p>
       </div>
     </ng-container>
 
-    <!-- EMPLOYEE VIEW (Default) -->
+    <!-- EMPLOYEE -->
     <ng-container *ngIf="userInfo.role === 'EMPLOYEE'">
-      <p-card>
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-gray-600">Hours This Month</p>
-            <p class="text-2xl text-gray-900 mt-2">168</p>
-            <p class="text-sm text-gray-600 mt-1">8 hours today</p>
-          </div>
-          <div class="bg-blue-500 p-3 rounded-lg">
-            <i class="pi pi-clock text-white text-lg"></i>
-          </div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Hours This Month</span>
+          <i class="pi pi-clock stat-icon"></i>
         </div>
-      </p-card>
-
-      <p-card>
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-gray-600">Leave Balance</p>
-            <p class="text-2xl text-gray-900 mt-2">
-              {{ (dashboardStats?.leaveBalance?.totalLeaves - dashboardStats?.leaveBalance?.usedLeaves) || 0 }} days
-            </p>
-            <p class="text-sm text-gray-600 mt-1">
-              {{ dashboardStats?.leaveBalance?.usedLeaves || 0 }} used this year
-            </p>
-          </div>
-          <div class="bg-green-500 p-3 rounded-lg">
-            <i class="pi pi-calendar text-white text-lg"></i>
-          </div>
+        <p class="stat-value">168</p>
+      </div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Leave Balance</span>
+          <i class="pi pi-calendar stat-icon"></i>
         </div>
-      </p-card>
+        <p class="stat-value">
+          {{ (dashboardStats?.leaveBalance?.totalLeaves - dashboardStats?.leaveBalance?.usedLeaves) || 0 }}<span class="stat-unit"> days</span>
+        </p>
+      </div>
     </ng-container>
 
-    <!-- Common Cards (Salary/Performance) - Show for everyone or specific roles? -->
-    <!-- Keeping them for Employee/Manager for now -->
+    <!-- EMPLOYEE + MANAGER shared -->
     <ng-container *ngIf="['EMPLOYEE', 'MANAGER'].includes(userInfo.role)">
-      <p-card>
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-gray-600">This Month Salary</p>
-            <p class="text-2xl text-gray-900 mt-2">$4,500</p>
-            <p class="text-sm text-gray-600 mt-1">Processed on 1st</p>
-          </div>
-          <div class="bg-purple-500 p-3 rounded-lg">
-            <i class="pi pi-dollar text-white text-lg"></i>
-          </div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Monthly Salary</span>
+          <i class="pi pi-dollar stat-icon"></i>
         </div>
-      </p-card>
-
-      <p-card>
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm text-gray-600">Performance Score</p>
-            <p class="text-2xl text-gray-900 mt-2">92%</p>
-            <p class="text-sm text-gray-600 mt-1">+5% this quarter</p>
-          </div>
-          <div class="bg-orange-500 p-3 rounded-lg">
-            <i class="pi pi-chart-line text-white text-lg"></i>
-          </div>
+        <p class="stat-value">$4,500</p>
+      </div>
+      <div class="stat-cell">
+        <div class="stat-header">
+          <span class="stat-label">Performance</span>
+          <i class="pi pi-chart-line stat-icon"></i>
         </div>
-      </p-card>
+        <p class="stat-value">92<span class="stat-unit">%</span></p>
+      </div>
     </ng-container>
+
   </div>
 
-  <!-- Recent Joiners (Admin Only) -->
-  <div *ngIf="userInfo.role === 'ADMIN'" class="grid grid-cols-1 gap-6">
-    <p-card header="Recent Joiners">
-      <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-              >
-                Name
-              </th>
-              <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-              >
-                Email
-              </th>
-              <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-              >
-                Designation
-              </th>
-              <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-              >
-                Joined Date
-              </th>
-            </tr>
-          </thead>
-          <tbody class="bg-white divide-y divide-gray-200">
-            <tr *ngFor="let employee of dashboardStats?.recentJoiners">
-              <td
-                class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
-              >
-                {{ employee.user.name }}
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                {{ employee.user.email }}
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                {{ employee.designation?.name || 'N/A' }}
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                {{ employee.joiningDate | date }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </p-card>
+  <!-- Recent Joiners (Admin only) -->
+  <div *ngIf="userInfo.role === 'ADMIN'" class="panel mb-6">
+    <div class="panel-header">
+      <h2 class="panel-title">Recent Joiners</h2>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="data-table w-full">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Designation</th>
+            <th>Joined</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let employee of dashboardStats?.recentJoiners">
+            <td class="font-medium">{{ employee.user.name }}</td>
+            <td>{{ employee.user.email }}</td>
+            <td>{{ employee.designation?.name || 'N/A' }}</td>
+            <td>{{ employee.joiningDate | date }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 
-  <!-- Attendance + Upcoming Leaves -->
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-    <!-- Attendance Chart -->
-    <p-card class="lg:col-span-2">
-      <ng-template pTemplate="header">
+  <!-- Attendance chart + Upcoming leaves -->
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+
+    <div class="panel lg:col-span-2">
+      <div class="panel-header">
         <div>
-          <h4>Attendance History</h4>
-          <p class="text-gray-500 text-sm">Last 7 working days</p>
-        </div>
-      </ng-template>
-      <p-chart
-        type="bar"
-        height="250px"
-        [data]="attendanceData"
-        [options]="chartOptions"
-      ></p-chart>
-      <div class="mt-4 p-4 bg-gray-50 rounded-lg">
-        <div class="flex items-center justify-between text-sm">
-          <span class="text-gray-600">Average hours per day</span>
-          <span class="text-gray-900">8.2 hours</span>
+          <h2 class="panel-title">Attendance History</h2>
+          <p class="panel-subtitle">Last 7 working days</p>
         </div>
       </div>
-    </p-card>
+      <p-chart type="bar" height="220px" [data]="attendanceData" [options]="chartOptions"></p-chart>
+    </div>
 
-    <!-- Upcoming Leaves -->
-    <p-card>
-      <ng-template pTemplate="header">
+    <div class="panel">
+      <div class="panel-header">
         <div>
-          <h4>Upcoming Leaves</h4>
-          <p class="text-gray-500 text-sm">Your scheduled time off</p>
+          <h2 class="panel-title">Upcoming Leaves</h2>
+          <p class="panel-subtitle">Scheduled time off</p>
         </div>
-      </ng-template>
-      <div class="flex flex-col gap-3">
-        <div
-          *ngFor="let leave of upcomingLeaves"
-          class="p-3 border border-gray-200 rounded-lg"
-        >
-          <div class="flex items-start justify-between mb-2">
-            <p class="text-sm text-gray-900">{{ leave.title }}</p>
-            <p-tag [value]="leave.status" severity="success"></p-tag>
+      </div>
+      <div class="flex flex-col gap-2">
+        <div *ngFor="let leave of upcomingLeaves" class="leave-item">
+          <div class="flex items-start justify-between gap-2 mb-1">
+            <p class="leave-title">{{ leave.title }}</p>
+            <p-tag [value]="leave.status" severity="success" [style]="{ fontSize: '0.7rem', padding: '2px 8px' }"></p-tag>
           </div>
-          <p class="text-xs text-gray-600">{{ leave.date }}</p>
-          <p class="text-xs text-gray-500 mt-1">{{ leave.away }}</p>
+          <p class="leave-date">{{ leave.date }}</p>
+          <p class="leave-away">{{ leave.away }}</p>
         </div>
-        <p-button label="Request Leave"></p-button>
+        <p class="leave-empty" *ngIf="!upcomingLeaves?.length">No upcoming leaves scheduled</p>
+        <p-button label="Request Leave" size="small" [outlined]="true" styleClass="w-full mt-2" />
       </div>
-    </p-card>
+    </div>
+
   </div>
 
-  <!-- Pending Tasks & Performance Goals -->
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-    <!-- Pending Tasks -->
-    <p-card>
-      <ng-template pTemplate="header">
-        <div>
-          <h4>Pending Tasks</h4>
-          <p class="text-gray-500 text-sm">Items requiring your attention</p>
-        </div>
-      </ng-template>
+  <!-- Pending tasks + Performance goals -->
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
 
-      <div class="space-y-3">
-        <div
-          *ngFor="let task of pendingTasks"
-          class="flex justify-between p-3 border border-gray-200 rounded-lg"
-        >
-          <div>
-            <p class="text-sm text-gray-900">{{ task.title }}</p>
-            <p class="text-xs text-gray-600 mt-1">Due: {{ task.due }}</p>
+    <div class="panel">
+      <div class="panel-header">
+        <h2 class="panel-title">Pending Tasks</h2>
+      </div>
+      <ul class="flex flex-col gap-2 list-none m-0 p-0">
+        <li *ngFor="let task of pendingTasks" class="task-item flex items-start justify-between gap-4">
+          <div class="min-w-0">
+            <p class="task-title">{{ task.title }}</p>
+            <p class="task-due">Due {{ task.due }}</p>
           </div>
-          <p-tag [value]="task.priority" [severity]="task.severity"></p-tag>
-        </div>
-      </div>
-    </p-card>
+          <p-tag [value]="task.priority" [severity]="task.severity"
+                 [style]="{ fontSize: '0.7rem', padding: '2px 8px', whiteSpace: 'nowrap' }"></p-tag>
+        </li>
+      </ul>
+    </div>
 
-    <!-- Performance Goals -->
-    <p-card>
-      <ng-template pTemplate="header">
+    <div class="panel">
+      <div class="panel-header">
         <div>
-          <h4>Performance Goals</h4>
-          <p class="text-gray-500 text-sm">Q4 2025 objectives</p>
+          <h2 class="panel-title">Performance Goals</h2>
+          <p class="panel-subtitle">Current quarter</p>
         </div>
-      </ng-template>
-
-      <div *ngFor="let goal of performanceGoals" class="mb-4">
-        <div class="flex justify-between mb-2 text-sm">
-          <span>{{ goal.title }}</span>
-          <span>{{ goal.progressLabel }}</span>
-        </div>
-        <p-progressBar [value]="goal.progress"></p-progressBar>
       </div>
-    </p-card>
+      <div class="flex flex-col gap-5">
+        <div *ngFor="let goal of performanceGoals">
+          <div class="flex items-center justify-between mb-2">
+            <span class="goal-title">{{ goal.title }}</span>
+            <span class="goal-label">{{ goal.progressLabel }}</span>
+          </div>
+          <p-progressBar [value]="goal.progress" [showValue]="false" [style]="{ height: '5px' }"></p-progressBar>
+        </div>
+      </div>
+    </div>
+
   </div>
 
-  <!-- Quick Actions -->
-  <p-card>
-    <ng-template pTemplate="header">
-      <h4>Quick Actions</h4>
-    </ng-template>
-
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-      <button
-        *ngFor="let action of quickActions"
-        class="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 flex flex-col items-start"
-      >
-        <i [class]="action.icon + ' h-6 w-6 mb-2 ' + action.color"></i>
-        <p class="text-gray-900">{{ action.label }}</p>
+  <!-- Quick actions -->
+  <div class="panel">
+    <div class="panel-header">
+      <h2 class="panel-title">Quick Actions</h2>
+    </div>
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <button *ngFor="let action of quickActions"
+              class="quick-action flex items-center gap-3 px-4 py-3 rounded-lg text-left w-full">
+        <i [class]="action.icon + ' quick-action-icon'"></i>
+        <span class="quick-action-label">{{ action.label }}</span>
       </button>
     </div>
-  </p-card>
+  </div>
+
 </div>

--- a/hrms-ui/src/app/features/layout/dashboard/dashboard.ts
+++ b/hrms-ui/src/app/features/layout/dashboard/dashboard.ts
@@ -140,7 +140,8 @@ export class Dashboard {
       datasets: [
         {
           label: 'Hours Worked',
-          backgroundColor: '#3B82F6',
+          backgroundColor: '#f97316',
+          borderRadius: 4,
           data: hours,
         },
       ],
@@ -226,9 +227,28 @@ export class Dashboard {
     this.chartOptions = {
       plugins: {
         legend: { display: false },
+        tooltip: {
+          backgroundColor: '#ffffff',
+          titleColor: '#111827',
+          bodyColor: '#6b7280',
+          borderColor: '#e5e7eb',
+          borderWidth: 1,
+          padding: 10,
+          cornerRadius: 6,
+        },
       },
       scales: {
-        y: { beginAtZero: true },
+        y: {
+          beginAtZero: true,
+          grid: { color: '#f3f4f6' },
+          border: { display: false },
+          ticks: { color: '#9ca3af', font: { size: 11 } },
+        },
+        x: {
+          grid: { display: false },
+          border: { display: false },
+          ticks: { color: '#9ca3af', font: { size: 11 } },
+        },
       },
     };
     console.log(this.attendanceData, 'chartdata');

--- a/hrms-ui/src/app/features/layout/layout.css
+++ b/hrms-ui/src/app/features/layout/layout.css
@@ -1,104 +1,106 @@
-.pi {
-  font-size: 1.3rem;
+/* Layout shell */
+.layout-shell {
+  background-color: var(--p-surface-50);
 }
 
-:host::ng-deep.p-panelmenu-panel {
-  border: none;
-  background-color: inherit;
+/* Sidebar */
+.sidebar {
+  background-color: var(--p-surface-0);
+  border-right: 1px solid var(--p-surface-200);
 }
 
-/* ===== Sidebar Enhancements ===== */
-.sidebar-container {
-  background: linear-gradient(
-    180deg,
-    var(--p-surface-50) 0%,
-    var(--p-surface-100) 100%
-  );
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+/* Brand bar — same height as topbar for visual alignment */
+.brand-bar {
+  height: 56px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--p-surface-200);
 }
 
-/* Menu Item Styles */
-.menu-item {
-  position: relative;
-  overflow: hidden;
+.brand-mark {
+  background-color: var(--p-primary-500);
 }
 
-.menu-item::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  height: 100%;
-  width: 3px;
-  background: var(--p-primary-500);
-  transform: scaleY(0);
-  transition: transform 0.2s ease;
+.brand-name {
+  color: var(--p-text-color);
+  letter-spacing: -0.01em;
 }
 
-.menu-item.active::before {
-  transform: scaleY(1);
+/* Nav items */
+.nav-link {
+  color: var(--p-text-muted-color);
+  transition: background-color 150ms ease-out, color 150ms ease-out;
 }
 
-.menu-item:hover {
-  background: var(--p-surface-100);
+.nav-link:hover {
+  background-color: var(--p-surface-100);
+  color: var(--p-text-color);
 }
 
-/* User Profile Section */
-.user-profile-section {
-  background: linear-gradient(
-    135deg,
-    var(--p-surface-0) 0%,
-    var(--p-surface-50) 100%
-  );
-  border-radius: 12px;
-  padding: 16px;
-  transition: all 0.3s ease;
+.nav-link-active {
+  background-color: var(--p-primary-50);
+  color: var(--p-primary-700);
 }
 
-.user-profile-section:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-  transform: translateY(-2px);
+.nav-icon {
+  font-size: 0.875rem;
+  width: 1rem;
+  text-align: center;
 }
 
-/* Avatar Styles */
+/* User bar */
+.user-bar {
+  border-top: 1px solid var(--p-surface-200);
+  flex-shrink: 0;
+}
+
 .user-avatar {
-  position: relative;
-  display: inline-block;
+  background-color: var(--p-primary-500);
 }
 
-.user-avatar::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  width: 12px;
-  height: 12px;
-  background: #10b981;
-  border: 2px solid white;
-  border-radius: 50%;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+.user-name {
+  color: var(--p-text-color);
 }
 
-/* Toolbar Enhancements */
-.modern-toolbar {
-  backdrop-filter: blur(10px);
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(0, 0, 0, 0.05);
+.user-role {
+  color: var(--p-text-muted-color);
 }
 
-/* Content Area */
-.content-area {
-  animation: fadeIn 0.3s ease-out;
+.sign-out-btn {
+  color: var(--p-text-muted-color);
+  transition: background-color 150ms ease-out, color 150ms ease-out;
+  cursor: pointer;
+  background: transparent;
+  border: none;
 }
 
-/* Card Icons */
-.card-icons {
-  font-size: 2rem;
-  opacity: 0.8;
-  transition: all 0.3s ease;
+.sign-out-btn:hover {
+  background-color: var(--p-surface-100);
+  color: var(--p-text-color);
 }
 
-.card-icons:hover {
-  opacity: 1;
-  transform: scale(1.1);
+/* Main column */
+.main-column {
+  background-color: var(--p-surface-50);
+}
+
+/* Topbar */
+.topbar {
+  height: 56px;
+  flex-shrink: 0;
+  background-color: var(--p-surface-0);
+  border-bottom: 1px solid var(--p-surface-200);
+}
+
+.avatar-btn {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--p-surface-200);
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+}
+
+/* Content */
+.main-content {
+  padding: 1.5rem;
 }

--- a/hrms-ui/src/app/features/layout/layout.html
+++ b/hrms-ui/src/app/features/layout/layout.html
@@ -1,109 +1,78 @@
-<div
-  class="w-full h-[100vh] p-6 flex flex-col lg:flex-row gap-6 overflow-hidden"
->
+<div class="layout-shell flex flex-col lg:flex-row h-screen overflow-hidden">
+
   <!-- Sidebar -->
-  <div
-    class="rounded-2xl p-5 sidebar-container dark:bg-surface-900 flex flex-col justify-between lg:w-80 w-full h-full shadow-medium border border-surface"
-  >
-    <!-- Menu -->
-    <p-panelmenu [model]="items" class="w-full">
-      <ng-template #item let-item>
-        <a
-          pRipple
-          class="flex items-center px-4 py-2 cursor-pointer group rounded-lg transition-colors duration-150"
-          (click)="navigate(item)"
-          [ngClass]="
-            activeRoute === item.route
-              ? 'text-primary-contrast bg-primary hover:bg-primary-emphasis'
-              : 'hover:bg-surface-100 dark:hover:bg-surface-800'
-          "
-        >
-          <i [class]="item.icon"></i>
-          <span class="ml-2 text-base truncate">{{ item.label }}</span>
+  <aside class="sidebar flex flex-col w-full lg:w-60 shrink-0 lg:h-full">
 
-          <p-badge *ngIf="item.badge" class="ml-auto" [value]="item.badge" />
-          <span
-            *ngIf="item.shortcut"
-            class="ml-auto border border-surface rounded bg-emphasis text-muted-color text-xs px-2 py-0.5"
-          >
-            {{ item.shortcut }}
-          </span>
-        </a>
-      </ng-template>
-    </p-panelmenu>
-
-    <!-- Footer: User Info + Logout -->
-    <div
-      class="pt-5 border-t border-surface-200 flex flex-col items-center w-full"
-    >
-      <div class="user-profile-section w-full mb-4">
-        <div class="flex items-center gap-4">
-          <div class="user-avatar">
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center text-lg font-bold text-white shadow-soft relative"
-              style="
-                background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-              "
-            >
-              <span class="relative z-10">{{ userDetails.initials }}</span>
-            </div>
-          </div>
-
-          <div class="flex-1 min-w-0">
-            <p
-              class="text-base font-semibold text-gray-900 dark:text-gray-100 truncate"
-            >
-              {{ userDetails.name }}
-            </p>
-            <p
-              class="text-xs text-gray-500 dark:text-gray-400 capitalize truncate"
-            >
-              {{ userDetails.role }}
-            </p>
-          </div>
-        </div>
+    <!-- Brand -->
+    <div class="brand-bar flex items-center gap-2.5 px-5">
+      <div class="brand-mark flex items-center justify-center w-6 h-6 rounded-lg">
+        <i class="pi pi-th-large" style="font-size: 0.75rem; color: white"></i>
       </div>
-
-      <p-button
-        icon="pi pi-sign-out"
-        label="Logout"
-        (click)="onLogoutClick()"
-        styleClass="p-button-sm p-button-text p-button-danger w-full justify-center font-medium hover:bg-red-50 hover:text-red-600 transition-all duration-150"
-      ></p-button>
+      <span class="brand-name text-sm font-semibold">PeopleOS</span>
     </div>
-  </div>
 
-  <!-- Main Section -->
-  <div class="flex-1 flex flex-col overflow-hidden">
-    <!-- Toolbar -->
-    <p-toolbar
-      [style]="{ 'border-radius': '1.5rem', padding: '1rem 1.5rem' }"
-      class="mb-4 shadow-soft modern-toolbar"
-    >
-      <ng-template #start>
-        <div class="flex items-center gap-2"></div>
-      </ng-template>
+    <!-- Nav -->
+    <nav class="flex-1 overflow-y-auto px-3 py-3" role="navigation" aria-label="Main navigation">
+      <ul class="flex flex-col gap-0.5 list-none m-0 p-0">
+        <li *ngFor="let item of items">
+          <a pRipple
+             class="nav-link flex items-center gap-3 px-3 py-2 rounded-md cursor-pointer select-none"
+             (click)="navigate(item)"
+             [class.nav-link-active]="activeRoute === item['route']"
+             [attr.aria-current]="activeRoute === item['route'] ? 'page' : null">
+            <i [class]="item.icon" class="nav-icon shrink-0"></i>
+            <span class="nav-label text-sm font-medium truncate">{{ item.label }}</span>
+            <p-badge *ngIf="item.badge" class="ml-auto" [value]="item.badge" />
+          </a>
+        </li>
+      </ul>
+    </nav>
 
-      <ng-template #end>
-        <div class="flex items-center gap-4">
-          <app-notification></app-notification>
-          <p-avatar
-            image="https://primefaces.org/cdn/primeng/images/demo/avatar/amyelsner.png"
-            [style]="{ width: '32px', height: '32px' }"
-          />
+    <!-- User -->
+    <div class="user-bar px-4 py-3">
+      <div class="flex items-center gap-3">
+        <div class="user-avatar flex items-center justify-center w-8 h-8 rounded-full text-xs font-bold text-white shrink-0">
+          {{ userDetails.initials }}
         </div>
-      </ng-template>
-    </p-toolbar>
+        <div class="flex-1 min-w-0">
+          <p class="user-name text-sm font-medium leading-tight truncate">{{ userDetails.name }}</p>
+          <p class="user-role text-xs leading-tight capitalize truncate">{{ userDetails.role }}</p>
+        </div>
+        <button class="sign-out-btn flex items-center justify-center w-7 h-7 rounded-md"
+                (click)="onLogoutClick()"
+                title="Sign out"
+                aria-label="Sign out">
+          <i class="pi pi-sign-out" style="font-size: 0.8rem"></i>
+        </button>
+      </div>
+    </div>
+
+  </aside>
+
+  <!-- Main -->
+  <div class="main-column flex-1 flex flex-col min-w-0 overflow-hidden">
+
+    <!-- Topbar -->
+    <header class="topbar flex items-center justify-end px-6">
+      <div class="flex items-center gap-2">
+        <app-notification></app-notification>
+        <button class="avatar-btn block rounded-full overflow-hidden" title="Profile" aria-label="User profile">
+          <img src="https://primefaces.org/cdn/primeng/images/demo/avatar/amyelsner.png"
+               class="block w-full h-full object-cover" alt="" />
+        </button>
+      </div>
+    </header>
 
     <!-- Content -->
-    <div
-      class="flex-1 overflow-auto bg-surface-50 dark:bg-surface-900 border border-surface rounded-2xl p-6 shadow-soft content-area"
-    >
+    <main class="main-content flex-1 overflow-auto">
       <router-outlet></router-outlet>
-    </div>
+    </main>
+
   </div>
+
 </div>
 
+<!-- Change Password Dialog -->
 <p-dialog
   header="Change Password"
   [modal]="true"
@@ -111,7 +80,7 @@
   [style]="{ width: '30vw' }"
   [breakpoints]="{ '1199px': '75vw', '575px': '90vw' }"
 >
-  <span class="p-text-secondary block mb-8">Update your information.</span>
+  <span class="p-text-secondary block mb-8">Update your password.</span>
   <form
     class="flex flex-col items-stretch justify-stretch gap-6"
     [formGroup]="changePasswordForm"
@@ -122,26 +91,18 @@
         <p-password
           [toggleMask]="true"
           formControlName="oldPassword"
-          inputId="on_pasword"
+          inputId="old_password"
           fluid
-        >
-        </p-password>
-        <label for="on_pasword">Old Password</label>
+        ></p-password>
+        <label for="old_password">Old Password</label>
       </p-floatlabel>
-      <!-- <ng-template [formError]="'oldPassword'" let-control>
-        @if(control.errors?.['required']) {
-        <p-message severity="error" size="small" variant="simple">
-          Password is required
-        </p-message>
-        }
-      </ng-template> -->
     </div>
     <div>
       <p-floatlabel variant="on">
         <p-password
           [toggleMask]="true"
           formControlName="newPassword"
-          inputId="on_pasword"
+          inputId="new_password"
           fluid
           appendTo="body"
         >
@@ -155,40 +116,20 @@
             </ul>
           </ng-template>
         </p-password>
-        <label for="on_pasword">New Password</label>
+        <label for="new_password">New Password</label>
       </p-floatlabel>
-      <!-- <ng-template [formError]="'newPassword'" let-control>
-        @if(control.errors?.['required']) {
-        <p-message severity="error" size="small" variant="simple">
-          Password is required
-        </p-message>
-        } @if(control.errors?.['passwordStrength']) {
-        <p-message severity="error" size="small" variant="simple">
-          Password must be at least 8 characters, include an uppercase letter,
-          number, and special character.
-        </p-message>
-        }
-      </ng-template> -->
     </div>
     <div>
       <p-floatlabel variant="on">
         <p-password
           [toggleMask]="true"
           formControlName="confirmPassword"
-          inputId="on_confirm_pasword"
+          inputId="confirm_password"
           fluid
         />
-        <label for="on_confirm_pasword">Confirm Password</label>
+        <label for="confirm_password">Confirm Password</label>
       </p-floatlabel>
-      <!-- <ng-template [formError]="'confirmPassword'" let-control>
-        @if(control.errors?.['passwordMismatch']) {
-        <p-message severity="error" size="small" variant="simple">
-          Passwords do not match.
-        </p-message>
-        }
-      </ng-template> -->
     </div>
-
     <button pButton type="submit">Change Password</button>
   </form>
 </p-dialog>

--- a/hrms-ui/src/app/features/layout/layout.ts
+++ b/hrms-ui/src/app/features/layout/layout.ts
@@ -7,7 +7,6 @@ import { AvatarModule } from 'primeng/avatar';
 import { InputTextModule } from 'primeng/inputtext';
 import { CommonModule } from '@angular/common';
 import { Ripple } from 'primeng/ripple';
-import { PanelMenuModule } from 'primeng/panelmenu';
 import { DividerModule } from 'primeng/divider';
 import { PopoverModule } from 'primeng/popover';
 import { ButtonModule } from 'primeng/button';
@@ -30,7 +29,6 @@ import { filter, Observable } from 'rxjs';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { AuthStateService } from '../../services/auth-state.service';
 import { Notification } from './notification/notification';
-import { ToolbarModule } from 'primeng/toolbar';
 
 @Component({
   selector: 'app-layout',
@@ -38,7 +36,6 @@ import { ToolbarModule } from 'primeng/toolbar';
     CommonModule,
     ReactiveFormsModule,
     RouterOutlet,
-    PanelMenuModule,
     BadgeModule,
     AvatarModule,
     InputTextModule,
@@ -55,7 +52,6 @@ import { ToolbarModule } from 'primeng/toolbar';
     FloatLabel,
     PasswordModule,
     Notification,
-    ToolbarModule,
   ],
   templateUrl: './layout.html',
   styleUrl: './layout.css',

--- a/hrms-ui/src/styles.css
+++ b/hrms-ui/src/styles.css
@@ -141,59 +141,12 @@ h6 {
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
-/* ===== Glass Morphism ===== */
-.glass {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.glass-dark {
-  background: rgba(0, 0, 0, 0.1);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border: 1px solid rgba(0, 0, 0, 0.2);
-}
-
 /* ===== Modern Card Styles ===== */
 .modern-card {
   background: var(--p-surface-0);
-  border-radius: 16px;
-  padding: 24px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  transition: all 0.3s ease;
-}
-
-.modern-card:hover {
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
-    0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  transform: translateY(-2px);
-}
-
-/* ===== Gradient Backgrounds ===== */
-.gradient-primary {
-  background: linear-gradient(
-    135deg,
-    var(--p-primary-500) 0%,
-    var(--p-primary-600) 100%
-  );
-}
-
-.gradient-success {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
-}
-
-.gradient-warning {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-}
-
-.gradient-danger {
-  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
-}
-
-.gradient-info {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  border-radius: 10px;
+  padding: 20px;
+  border: 1px solid var(--p-surface-200);
 }
 
 /* ===== Input Enhancements ===== */
@@ -206,20 +159,6 @@ h6 {
   box-shadow: 0 0 0 3px rgba(var(--p-primary-500), 0.1);
 }
 
-/* ===== Button Enhancements ===== */
-.p-button {
-  transition: all 0.2s ease;
-}
-
-.p-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
-    0 2px 4px -1px rgba(0, 0, 0, 0.06);
-}
-
-.p-button:active:not(:disabled) {
-  transform: translateY(0);
-}
 
 /* ===== Table Enhancements ===== */
 .p-datatable .p-datatable-tbody > tr {
@@ -261,14 +200,6 @@ h6 {
   border-top-right-radius: 16px;
 }
 
-/* ===== Sidebar Menu Enhancements ===== */
-.p-panelmenu .p-panelmenu-header-link {
-  transition: all 0.2s ease;
-}
-
-.p-panelmenu .p-panelmenu-header-link:hover {
-  background-color: var(--p-surface-100);
-}
 
 /* ===== Utility Classes ===== */
 .shadow-soft {
@@ -283,16 +214,6 @@ h6 {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
 }
 
-.text-gradient {
-  background: linear-gradient(
-    135deg,
-    var(--p-primary-500),
-    var(--p-primary-700)
-  );
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
 
 /* ===== Focus Visible for Accessibility ===== */
 *:focus-visible {


### PR DESCRIPTION
## Summary

- Replace gradient metric cards, glassmorphism toolbar, and PanelMenu accordion nav with a clean full-bleed layout
- Sidebar: flush 240px, `border-right`, brand bar at top, simple `ngFor` nav with accent-only active state, compact user footer
- Topbar: 56px, white, `border-bottom`, no floating card
- Dashboard stats: flat white bordered cells per role (no gradient accents, no radial decorations, no hero-metric template)
- Remove side-stripe pseudo-elements, hover transforms on cards/buttons, `text-gradient` utility, glassmorphism utilities
- Update Chart.js bar color to orange primary (`#f97316`) with cleaner grid/tooltip options
- Build passes clean (Angular 20, no TS errors)

## Test plan

- [ ] Log in and verify sidebar renders nav items with correct active highlight for current route
- [ ] Check that clock in/out button and today's status appear in the dashboard header
- [ ] Verify stats grid renders correct cells per role: ADMIN (4), HR (4), MANAGER (3), EMPLOYEE (4)
- [ ] Confirm attendance bar chart renders in orange with clean axes
- [ ] Check upcoming leaves, pending tasks, performance goals, and quick actions sections
- [ ] Verify Recent Joiners table appears for ADMIN role only
- [ ] Test logout button in sidebar user footer
- [ ] Check layout at `lg` breakpoint and below (sidebar stacks above content on mobile)

https://claude.ai/code/session_0118eKEu4D4XTXea1jRxm6v1

---
_Generated by [Claude Code](https://claude.ai/code/session_0118eKEu4D4XTXea1jRxm6v1)_