### PR TITLE
Fix employee edit name, pagination & card counts; redesign employee screen

### DIFF
--- a/hrms-backend/src/services/employee.service.ts
+++ b/hrms-backend/src/services/employee.service.ts
@@ -20,7 +20,9 @@ export interface CreateEmployeeDto {
   emergencyContactNumber?: string;
 }
 
-export interface UpdateEmployeeDto extends Partial<Omit<CreateEmployeeDto, 'userId'>> {}
+export interface UpdateEmployeeDto extends Partial<Omit<CreateEmployeeDto, 'userId'>> {
+  name?: string;
+}
 
 export interface ListEmployeesDto {
   pageno?: number;
@@ -88,6 +90,7 @@ export class EmployeeService {
     return prisma.employee.update({
       where: { id },
       data: {
+        ...(dto.name ? { user: { update: { name: dto.name } } } : {}),
         employeeCode: dto.employeeCode?.trim(),
         departmentId: dto.departmentId,
         designationId: dto.designationId,
@@ -181,10 +184,11 @@ export class EmployeeService {
   async getSummary() {
     const [totalEmployees, activeEmployees, newEmployees, totalDepartments] =
       await Promise.all([
-        prisma.employee.count(),
-        prisma.employee.count({ where: { status: EmployeeStatus.ACTIVE } }),
+        prisma.employee.count({ where: { ...notDeleted } }),
+        prisma.employee.count({ where: { ...notDeleted, status: EmployeeStatus.ACTIVE } }),
         prisma.employee.count({
           where: {
+            ...notDeleted,
             joiningDate: {
               gte: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
             },

--- a/hrms-ui/src/app/features/layout/employee/employee.css
+++ b/hrms-ui/src/app/features/layout/employee/employee.css
@@ -6,18 +6,15 @@
 }
 
 @media (max-width: 900px) {
-  .metrics-row {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  .metrics-row { grid-template-columns: repeat(2, 1fr); }
 }
-
 @media (max-width: 480px) {
-  .metrics-row {
-    grid-template-columns: 1fr;
-  }
+  .metrics-row { grid-template-columns: 1fr; }
 }
 
 .metric-card {
+  position: relative;
+  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -25,29 +22,31 @@
   padding: 1.25rem 1.5rem;
   background: var(--p-surface-card);
   border: 1px solid var(--p-surface-border);
-  border-radius: 10px;
-  transition: box-shadow 0.2s ease-out;
+  border-radius: 12px;
+  transition: box-shadow 0.2s ease-out, transform 0.2s ease-out;
 }
 
 .metric-card:hover {
-  box-shadow: 0 4px 20px oklch(0 0 0 / 0.06);
+  box-shadow: 0 4px 24px oklch(0 0 0 / 0.07);
+  transform: translateY(-1px);
 }
 
 .metric-value {
   display: block;
-  font-size: 2rem;
+  font-size: 1.875rem;
   font-weight: 700;
   line-height: 1;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.03em;
   color: var(--p-text-color);
   margin-bottom: 0.375rem;
 }
 
 .metric-label {
   display: block;
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   color: var(--p-text-muted-color);
   font-weight: 500;
+  letter-spacing: 0.02em;
 }
 
 .metric-icon {
@@ -55,30 +54,87 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 8px;
-  font-size: 1rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 10px;
+  font-size: 1.125rem;
 }
 
-.metric-icon.icon-blue {
-  background: var(--p-blue-50);
-  color: var(--p-blue-500);
+.metric-icon.icon-blue   { background: oklch(94% 0.05 250); color: oklch(48% 0.18 250); }
+.metric-icon.icon-green  { background: oklch(94% 0.06 145); color: oklch(44% 0.18 145); }
+.metric-icon.icon-indigo { background: oklch(93% 0.05 270); color: oklch(48% 0.18 270); }
+.metric-icon.icon-violet { background: oklch(93% 0.05 295); color: oklch(48% 0.18 295); }
+
+/* ── Table filter bar ── */
+.table-filters {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
-.metric-icon.icon-green {
-  background: var(--p-green-50);
-  color: var(--p-green-600);
+.filters-left {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex-wrap: wrap;
 }
 
-.metric-icon.icon-indigo {
-  background: var(--p-indigo-50);
-  color: var(--p-indigo-500);
+.filters-right {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 }
 
-.metric-icon.icon-violet {
-  background: var(--p-violet-50);
-  color: var(--p-violet-500);
+.search-input {
+  width: 13rem;
+}
+
+.filter-select {
+  width: 9.5rem;
+}
+
+/* ── Employee name cell ── */
+.emp-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.emp-avatar {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--p-primary-100, oklch(93% 0.05 250));
+  color: var(--p-primary-600, oklch(46% 0.18 250));
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.emp-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--p-text-color);
+  line-height: 1.3;
+}
+
+.emp-email {
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+  line-height: 1.3;
+}
+
+.emp-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--p-text-muted-color);
 }
 
 /* ── Form sections ── */

--- a/hrms-ui/src/app/features/layout/employee/employee.html
+++ b/hrms-ui/src/app/features/layout/employee/employee.html
@@ -51,20 +51,26 @@
   <!-- ── Employee table ── -->
   <p-table
     [value]="employees"
+    [lazy]="true"
     [paginator]="true"
     [rows]="apiParams.top"
     [tableStyle]="{ 'min-width': '50rem' }"
-    (onPage)="pageChange($event)"
+    (onLazyLoad)="onLazyLoad($event)"
     [showCurrentPageReport]="true"
     currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
     [rowsPerPageOptions]="[5, 10, 20]"
     [totalRecords]="totalRecords"
     [first]="apiParams.pageno"
+    styleClass="p-datatable-sm"
   >
     <ng-template #caption>
-      <form [formGroup]="filterForm" class="flex gap-3 flex-wrap items-center justify-between">
-        <div class="flex gap-3 flex-wrap items-end">
-          <p-floatlabel variant="on" class="w-44">
+      <form [formGroup]="filterForm" class="table-filters">
+        <div class="filters-left">
+          <p-iconfield iconPosition="left">
+            <p-inputicon><i class="pi pi-search"></i></p-inputicon>
+            <input pInputText type="text" [formControl]="searchControl" placeholder="Search employees…" class="search-input" />
+          </p-iconfield>
+          <p-floatlabel variant="on" class="filter-select">
             <p-select
               formControlName="departmentId"
               [options]="options?.['DEPARTMENTS']"
@@ -75,7 +81,7 @@
             />
             <label>Department</label>
           </p-floatlabel>
-          <p-floatlabel variant="on" class="w-36">
+          <p-floatlabel variant="on" class="filter-select">
             <p-select
               formControlName="status"
               [options]="options?.['EMPLOYEE_STATUS']"
@@ -86,7 +92,7 @@
             />
             <label>Status</label>
           </p-floatlabel>
-          <p-floatlabel variant="on" class="w-44">
+          <p-floatlabel variant="on" class="filter-select">
             <p-select
               formControlName="designationId"
               [options]="options?.['DESIGNATIONS']"
@@ -98,11 +104,7 @@
             <label>Designation</label>
           </p-floatlabel>
         </div>
-        <div class="flex gap-2 items-center">
-          <p-iconfield iconPosition="left">
-            <p-inputicon><i class="pi pi-search"></i></p-inputicon>
-            <input pInputText type="text" [formControl]="searchControl" placeholder="Search employees" />
-          </p-iconfield>
+        <div class="filters-right">
           <p-button label="Apply" [outlined]="true" size="small" icon="pi pi-check" (click)="applyFilter()" />
           <p-button label="Clear" [outlined]="true" size="small" severity="secondary" icon="pi pi-filter-slash" (click)="clearFilter()" />
         </div>
@@ -111,25 +113,31 @@
 
     <ng-template #header>
       <tr>
-        <th>Code</th>
-        <th>Name</th>
-        <th>Email</th>
+        <th style="width:7rem">Code</th>
+        <th>Employee</th>
         <th>Department</th>
         <th>Designation</th>
-        <th>Joined</th>
-        <th>Status</th>
-        <th>Actions</th>
+        <th style="width:8rem">Joined</th>
+        <th style="width:7rem">Status</th>
+        <th style="width:9rem">Actions</th>
       </tr>
     </ng-template>
 
     <ng-template #body let-employee>
       <tr>
-        <td class="font-mono text-sm font-medium">{{ employee.employeeCode }}</td>
-        <td class="font-medium">{{ employee.user.name }}</td>
-        <td class="text-sm text-muted-color">{{ employee.user.email }}</td>
-        <td>{{ employee.department?.name || '—' }}</td>
-        <td>{{ employee.designation?.name || '—' }}</td>
-        <td class="text-sm">{{ employee.joiningDate | date : 'dd MMM yyyy' }}</td>
+        <td><span class="emp-code">{{ employee.employeeCode }}</span></td>
+        <td>
+          <div class="emp-cell">
+            <div class="emp-avatar">{{ getInitials(employee.user.name) }}</div>
+            <div>
+              <div class="emp-name">{{ employee.user.name }}</div>
+              <div class="emp-email">{{ employee.user.email }}</div>
+            </div>
+          </div>
+        </td>
+        <td class="text-sm">{{ employee.department?.name || '—' }}</td>
+        <td class="text-sm">{{ employee.designation?.name || '—' }}</td>
+        <td class="text-sm text-muted-color">{{ employee.joiningDate | date : 'dd MMM yyyy' }}</td>
         <td>
           <p-tag
             [severity]="employee.status === 'ACTIVE' ? 'success' : 'danger'"
@@ -138,11 +146,11 @@
           />
         </td>
         <td>
-          <div class="flex gap-1">
-            <p-button icon="pi pi-eye" [rounded]="true" [text]="true" size="small" (click)="onView(employee)" />
-            <p-button icon="pi pi-pencil" [rounded]="true" [text]="true" size="small" (click)="onEdit(employee)" />
-            <p-button icon="pi pi-money-bill" [rounded]="true" [text]="true" size="small" (click)="onGeneratePayroll(employee)" />
-            <p-button icon="pi pi-trash" [rounded]="true" [text]="true" size="small" severity="danger" (click)="onDelete($event, employee)" />
+          <div class="flex gap-0.5">
+            <p-button icon="pi pi-eye" [rounded]="true" [text]="true" size="small" pTooltip="View" tooltipPosition="top" (click)="onView(employee)" />
+            <p-button icon="pi pi-pencil" [rounded]="true" [text]="true" size="small" pTooltip="Edit" tooltipPosition="top" (click)="onEdit(employee)" />
+            <p-button icon="pi pi-money-bill" [rounded]="true" [text]="true" size="small" pTooltip="Payroll" tooltipPosition="top" (click)="onGeneratePayroll(employee)" />
+            <p-button icon="pi pi-trash" [rounded]="true" [text]="true" size="small" severity="danger" pTooltip="Remove" tooltipPosition="top" (click)="onDelete($event, employee)" />
           </div>
         </td>
       </tr>
@@ -150,7 +158,10 @@
 
     <ng-template #emptymessage>
       <tr>
-        <td colspan="8" class="text-center py-12 text-muted-color text-sm">No employees found.</td>
+        <td colspan="7" class="text-center py-14 text-muted-color text-sm">
+          <i class="pi pi-users text-3xl block mb-3 opacity-30"></i>
+          No employees found.
+        </td>
       </tr>
     </ng-template>
   </p-table>
@@ -512,173 +523,195 @@
   [style]="{ width: '52rem' }"
   [breakpoints]="{ '1199px': '75vw', '575px': '92vw' }"
   [draggable]="false"
+  (onHide)="onEditDialogHide()"
 >
-  <form [formGroup]="addEmployeeForm" class="pt-4">
+  <div class="pt-4">
 
+    <!-- Name field (updates user.name) -->
     <div class="section-block">
       <div class="section-header">
-        <i class="pi pi-briefcase section-icon"></i>
-        <span class="section-title">Work Details</span>
+        <i class="pi pi-user section-icon"></i>
+        <span class="section-title">Account</span>
       </div>
-      <div class="grid grid-cols-2 gap-x-5 gap-y-6">
-
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <input pInputText formControlName="employeeCode" class="w-full"
-              [invalid]="addEmployeeForm.controls['employeeCode'].invalid && addEmployeeForm.controls['employeeCode'].touched" />
-            <label>Employee Code</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['employeeCode'].invalid && addEmployeeForm.controls['employeeCode'].touched) {
-            <p-message severity="error" size="small" variant="simple">Employee code is required.</p-message>
-          }
-        </div>
-
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <p-select formControlName="departmentId" [options]="options?.['DEPARTMENTS']" optionLabel="display_text" optionValue="value"
-              class="w-full" appendTo="body"
-              [invalid]="addEmployeeForm.controls['departmentId'].invalid && addEmployeeForm.controls['departmentId'].touched" />
-            <label>Department</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['departmentId'].invalid && addEmployeeForm.controls['departmentId'].touched) {
-            <p-message severity="error" size="small" variant="simple">Department is required.</p-message>
-          }
-        </div>
-
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <p-select formControlName="designationId" [options]="options?.['DESIGNATIONS']" optionLabel="display_text" optionValue="value"
-              class="w-full" appendTo="body"
-              [invalid]="addEmployeeForm.controls['designationId'].invalid && addEmployeeForm.controls['designationId'].touched" />
-            <label>Designation</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['designationId'].invalid && addEmployeeForm.controls['designationId'].touched) {
-            <p-message severity="error" size="small" variant="simple">Designation is required.</p-message>
-          }
-        </div>
-
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <p-datepicker formControlName="joiningDate" class="w-full" dateFormat="dd/mm/yy" appendTo="body"
-              [invalid]="addEmployeeForm.controls['joiningDate'].invalid && addEmployeeForm.controls['joiningDate'].touched" />
-            <label>Joining Date</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['joiningDate'].invalid && addEmployeeForm.controls['joiningDate'].touched) {
-            <p-message severity="error" size="small" variant="simple">Joining date is required.</p-message>
-          }
-        </div>
-
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <p-inputnumber formControlName="salary" class="w-full" [useGrouping]="true" prefix="₹ "
-              [invalid]="addEmployeeForm.controls['salary'].invalid && addEmployeeForm.controls['salary'].touched" />
-            <label>Annual Salary</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['salary'].invalid && addEmployeeForm.controls['salary'].touched) {
-            <p-message severity="error" size="small" variant="simple">Salary is required.</p-message>
-          }
-        </div>
-
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <p-select formControlName="managerId" [options]="options?.['MANAGERS']" optionLabel="display_text" optionValue="value"
-              class="w-full" appendTo="body"
-              [invalid]="addEmployeeForm.controls['managerId'].invalid && addEmployeeForm.controls['managerId'].touched" />
-            <label>Reporting Manager</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['managerId'].invalid && addEmployeeForm.controls['managerId'].touched) {
-            <p-message severity="error" size="small" variant="simple">Manager is required for this role.</p-message>
-          }
-        </div>
-
+      <div>
+        <p-floatlabel class="w-full" variant="on">
+          <input pInputText [formControl]="editNameControl" class="w-full"
+            [invalid]="editNameControl.invalid && editNameControl.touched" />
+          <label>Full Name</label>
+        </p-floatlabel>
+        @if (editNameControl.invalid && editNameControl.touched) {
+          <p-message severity="error" size="small" variant="simple">Name is required.</p-message>
+        }
       </div>
     </div>
 
-    <div class="section-block">
-      <div class="section-header">
-        <i class="pi pi-id-card section-icon"></i>
-        <span class="section-title">Personal Information</span>
+    <form [formGroup]="addEmployeeForm">
+
+      <div class="section-block">
+        <div class="section-header">
+          <i class="pi pi-briefcase section-icon"></i>
+          <span class="section-title">Work Details</span>
+        </div>
+        <div class="grid grid-cols-2 gap-x-5 gap-y-6">
+
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <input pInputText formControlName="employeeCode" class="w-full"
+                [invalid]="addEmployeeForm.controls['employeeCode'].invalid && addEmployeeForm.controls['employeeCode'].touched" />
+              <label>Employee Code</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['employeeCode'].invalid && addEmployeeForm.controls['employeeCode'].touched) {
+              <p-message severity="error" size="small" variant="simple">Employee code is required.</p-message>
+            }
+          </div>
+
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <p-select formControlName="departmentId" [options]="options?.['DEPARTMENTS']" optionLabel="display_text" optionValue="value"
+                class="w-full" appendTo="body"
+                [invalid]="addEmployeeForm.controls['departmentId'].invalid && addEmployeeForm.controls['departmentId'].touched" />
+              <label>Department</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['departmentId'].invalid && addEmployeeForm.controls['departmentId'].touched) {
+              <p-message severity="error" size="small" variant="simple">Department is required.</p-message>
+            }
+          </div>
+
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <p-select formControlName="designationId" [options]="options?.['DESIGNATIONS']" optionLabel="display_text" optionValue="value"
+                class="w-full" appendTo="body"
+                [invalid]="addEmployeeForm.controls['designationId'].invalid && addEmployeeForm.controls['designationId'].touched" />
+              <label>Designation</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['designationId'].invalid && addEmployeeForm.controls['designationId'].touched) {
+              <p-message severity="error" size="small" variant="simple">Designation is required.</p-message>
+            }
+          </div>
+
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <p-datepicker formControlName="joiningDate" class="w-full" dateFormat="dd/mm/yy" appendTo="body"
+                [invalid]="addEmployeeForm.controls['joiningDate'].invalid && addEmployeeForm.controls['joiningDate'].touched" />
+              <label>Joining Date</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['joiningDate'].invalid && addEmployeeForm.controls['joiningDate'].touched) {
+              <p-message severity="error" size="small" variant="simple">Joining date is required.</p-message>
+            }
+          </div>
+
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <p-inputnumber formControlName="salary" class="w-full" [useGrouping]="true" prefix="₹ "
+                [invalid]="addEmployeeForm.controls['salary'].invalid && addEmployeeForm.controls['salary'].touched" />
+              <label>Annual Salary</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['salary'].invalid && addEmployeeForm.controls['salary'].touched) {
+              <p-message severity="error" size="small" variant="simple">Salary is required.</p-message>
+            }
+          </div>
+
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <p-select formControlName="managerId" [options]="options?.['MANAGERS']" optionLabel="display_text" optionValue="value"
+                class="w-full" appendTo="body"
+                [invalid]="addEmployeeForm.controls['managerId'].invalid && addEmployeeForm.controls['managerId'].touched" />
+              <label>Reporting Manager</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['managerId'].invalid && addEmployeeForm.controls['managerId'].touched) {
+              <p-message severity="error" size="small" variant="simple">Manager is required for this role.</p-message>
+            }
+          </div>
+
+        </div>
       </div>
-      <div class="grid grid-cols-2 gap-x-5 gap-y-6">
 
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <p-datepicker formControlName="dob" class="w-full" dateFormat="dd/mm/yy" appendTo="body"
-              [invalid]="addEmployeeForm.controls['dob'].invalid && addEmployeeForm.controls['dob'].touched" />
-            <label>Date of Birth</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['dob'].invalid && addEmployeeForm.controls['dob'].touched) {
-            <p-message severity="error" size="small" variant="simple">Date of birth is required.</p-message>
-          }
+      <div class="section-block">
+        <div class="section-header">
+          <i class="pi pi-id-card section-icon"></i>
+          <span class="section-title">Personal Information</span>
         </div>
+        <div class="grid grid-cols-2 gap-x-5 gap-y-6">
 
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <p-select formControlName="bloodGroup" [options]="bloodGroupOptions" optionLabel="label" optionValue="value"
-              class="w-full" appendTo="body"
-              [invalid]="addEmployeeForm.controls['bloodGroup'].invalid && addEmployeeForm.controls['bloodGroup'].touched" />
-            <label>Blood Group</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['bloodGroup'].invalid && addEmployeeForm.controls['bloodGroup'].touched) {
-            <p-message severity="error" size="small" variant="simple">Blood group is required.</p-message>
-          }
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <p-datepicker formControlName="dob" class="w-full" dateFormat="dd/mm/yy" appendTo="body"
+                [invalid]="addEmployeeForm.controls['dob'].invalid && addEmployeeForm.controls['dob'].touched" />
+              <label>Date of Birth</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['dob'].invalid && addEmployeeForm.controls['dob'].touched) {
+              <p-message severity="error" size="small" variant="simple">Date of birth is required.</p-message>
+            }
+          </div>
+
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <p-select formControlName="bloodGroup" [options]="bloodGroupOptions" optionLabel="label" optionValue="value"
+                class="w-full" appendTo="body"
+                [invalid]="addEmployeeForm.controls['bloodGroup'].invalid && addEmployeeForm.controls['bloodGroup'].touched" />
+              <label>Blood Group</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['bloodGroup'].invalid && addEmployeeForm.controls['bloodGroup'].touched) {
+              <p-message severity="error" size="small" variant="simple">Blood group is required.</p-message>
+            }
+          </div>
+
+          <div class="col-span-2">
+            <p-floatlabel class="w-full" variant="on">
+              <input pInputText type="email" formControlName="personalEmail" class="w-full"
+                [invalid]="addEmployeeForm.controls['personalEmail'].invalid && addEmployeeForm.controls['personalEmail'].touched" />
+              <label>Personal Email</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['personalEmail'].invalid && addEmployeeForm.controls['personalEmail'].touched) {
+              <p-message severity="error" size="small" variant="simple">
+                @if (addEmployeeForm.controls['personalEmail'].hasError('required')) { Personal email is required. }
+                @if (addEmployeeForm.controls['personalEmail'].hasError('email')) { Enter a valid email address. }
+              </p-message>
+            }
+          </div>
+
         </div>
-
-        <div class="col-span-2">
-          <p-floatlabel class="w-full" variant="on">
-            <input pInputText type="email" formControlName="personalEmail" class="w-full"
-              [invalid]="addEmployeeForm.controls['personalEmail'].invalid && addEmployeeForm.controls['personalEmail'].touched" />
-            <label>Personal Email</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['personalEmail'].invalid && addEmployeeForm.controls['personalEmail'].touched) {
-            <p-message severity="error" size="small" variant="simple">
-              @if (addEmployeeForm.controls['personalEmail'].hasError('required')) { Personal email is required. }
-              @if (addEmployeeForm.controls['personalEmail'].hasError('email')) { Enter a valid email address. }
-            </p-message>
-          }
-        </div>
-
       </div>
-    </div>
 
-    <div class="section-block">
-      <div class="section-header">
-        <i class="pi pi-phone section-icon"></i>
-        <span class="section-title">Emergency Contact</span>
-      </div>
-      <div class="grid grid-cols-2 gap-x-5 gap-y-6">
-
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <input pInputText formControlName="emergencyContactPerson" class="w-full"
-              [invalid]="addEmployeeForm.controls['emergencyContactPerson'].invalid && addEmployeeForm.controls['emergencyContactPerson'].touched" />
-            <label>Contact Person</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['emergencyContactPerson'].invalid && addEmployeeForm.controls['emergencyContactPerson'].touched) {
-            <p-message severity="error" size="small" variant="simple">Emergency contact name is required.</p-message>
-          }
+      <div class="section-block">
+        <div class="section-header">
+          <i class="pi pi-phone section-icon"></i>
+          <span class="section-title">Emergency Contact</span>
         </div>
+        <div class="grid grid-cols-2 gap-x-5 gap-y-6">
 
-        <div>
-          <p-floatlabel class="w-full" variant="on">
-            <input pInputText type="tel" formControlName="emergencyContactNumber" class="w-full"
-              [invalid]="addEmployeeForm.controls['emergencyContactNumber'].invalid && addEmployeeForm.controls['emergencyContactNumber'].touched" />
-            <label>Contact Number</label>
-          </p-floatlabel>
-          @if (addEmployeeForm.controls['emergencyContactNumber'].invalid && addEmployeeForm.controls['emergencyContactNumber'].touched) {
-            <p-message severity="error" size="small" variant="simple">Emergency contact number is required.</p-message>
-          }
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <input pInputText formControlName="emergencyContactPerson" class="w-full"
+                [invalid]="addEmployeeForm.controls['emergencyContactPerson'].invalid && addEmployeeForm.controls['emergencyContactPerson'].touched" />
+              <label>Contact Person</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['emergencyContactPerson'].invalid && addEmployeeForm.controls['emergencyContactPerson'].touched) {
+              <p-message severity="error" size="small" variant="simple">Emergency contact name is required.</p-message>
+            }
+          </div>
+
+          <div>
+            <p-floatlabel class="w-full" variant="on">
+              <input pInputText type="tel" formControlName="emergencyContactNumber" class="w-full"
+                [invalid]="addEmployeeForm.controls['emergencyContactNumber'].invalid && addEmployeeForm.controls['emergencyContactNumber'].touched" />
+              <label>Contact Number</label>
+            </p-floatlabel>
+            @if (addEmployeeForm.controls['emergencyContactNumber'].invalid && addEmployeeForm.controls['emergencyContactNumber'].touched) {
+              <p-message severity="error" size="small" variant="simple">Emergency contact number is required.</p-message>
+            }
+          </div>
+
         </div>
-
       </div>
-    </div>
 
-    <div class="flex justify-end gap-2 pt-2">
-      <p-button label="Cancel" severity="secondary" [outlined]="true" (onClick)="editEmployeeDialog = false" />
-      <p-button label="Save Changes" icon="pi pi-check" (onClick)="onEditEmployee()" />
-    </div>
+      <div class="flex justify-end gap-2 pt-2">
+        <p-button label="Cancel" severity="secondary" [outlined]="true" (onClick)="editEmployeeDialog = false" />
+        <p-button label="Save Changes" icon="pi pi-check" (onClick)="onEditEmployee()" />
+      </div>
 
-  </form>
+    </form>
+  </div>
 </p-dialog>
 
 

--- a/hrms-ui/src/app/features/layout/employee/employee.ts
+++ b/hrms-ui/src/app/features/layout/employee/employee.ts
@@ -8,6 +8,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
+import { TooltipModule } from 'primeng/tooltip';
 import { ButtonModule } from 'primeng/button';
 import { TableModule } from 'primeng/table';
 import { InputTextModule } from 'primeng/inputtext';
@@ -52,6 +53,7 @@ const BLOOD_GROUPS = ['A+', 'A-', 'B+', 'B-', 'AB+', 'AB-', 'O+', 'O-'].map(
     StepperModule,
     PasswordModule,
     DividerModule,
+    TooltipModule,
   ],
   templateUrl: './employee.html',
   styleUrl: './employee.css',
@@ -76,6 +78,7 @@ export class Employee implements OnInit {
   activeStep: number = 1;
   lastEmployeeCode = '';
   editingEmployeeId: string | null = null;
+  editNameControl = new FormControl('', [Validators.required]);
   bloodGroupOptions = BLOOD_GROUPS;
 
   employeeSummary: any = {
@@ -147,7 +150,6 @@ export class Employee implements OnInit {
   }
 
   async ngOnInit() {
-    this.loadEmployees();
     this.loadEmployeeSummary();
     const data: any = await this.serverApi.get('/api/master-data');
     this.options = data;
@@ -184,8 +186,17 @@ export class Employee implements OnInit {
     this.cdr.detectChanges();
   }
 
+  onLazyLoad(event: any) {
+    this.loadEmployees({ pageno: event.first, top: event.rows });
+  }
+
   pageChange(event: any) {
     this.loadEmployees({ pageno: event.first, top: event.rows });
+  }
+
+  getInitials(name: string): string {
+    if (!name) return '?';
+    return name.split(' ').map((n) => n[0]).join('').toUpperCase().slice(0, 2);
   }
 
   applyFilter() {
@@ -275,7 +286,15 @@ export class Employee implements OnInit {
       salary: employeeDetails.salary,
     });
 
+    this.editNameControl.setValue(employee.user.name);
     this.editEmployeeDialog = true;
+  }
+
+  onEditDialogHide() {
+    this.editNameControl.reset();
+    this.addEmployeeForm.reset();
+    this.addEmployeeForm.get('employeeCode')?.enable();
+    this.editingEmployeeId = null;
   }
 
   async onAddEmploeeDialog() {
@@ -318,15 +337,13 @@ export class Employee implements OnInit {
 
   async onEditEmployee() {
     this.addEmployeeForm.markAllAsTouched();
-    if (!this.addEmployeeForm.valid) return;
+    this.editNameControl.markAsTouched();
+    if (!this.addEmployeeForm.valid || !this.editNameControl.valid) return;
     if (!this.editingEmployeeId) return;
 
-    const payload = this.addEmployeeForm.getRawValue();
+    const payload = { ...this.addEmployeeForm.getRawValue(), name: this.editNameControl.value };
     await this.serverApi.put(`/api/employees/${this.editingEmployeeId}`, payload);
-    this.addEmployeeForm.reset();
-    this.addEmployeeForm.get('employeeCode')?.enable();
     this.editEmployeeDialog = false;
-    this.editingEmployeeId = null;
     this.messageService.add({
       severity: 'success',
       summary: 'Changes saved',


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Edit employee name bug** — The edit dialog now includes a "Full Name" field backed by a dedicated `editNameControl`. On save, the name is sent in the PUT payload and the backend applies a nested Prisma `user: { update: { name } }` to persist the change.
- **Pagination bug** — Added `[lazy]="true"` to the PrimeNG table and switched `(onPage)` → `(onLazyLoad)`. Without lazy mode, PrimeNG sliced the 10-record local array client-side and showed nothing on page 2. The table now trusts `totalRecords` from the server for the paginator.
- **Card count bug** — `getSummary()` was calling `prisma.employee.count()` with no filter, counting soft-deleted records. All three employee counts now spread `notDeleted` (`{ deletedAt: null }`).
- **Redesign** — Polished minimal look: avatar initials cell (name + email stacked), metric cards with hover lift, refined filter bar, tooltips on action buttons, email column merged into the employee cell (7 cols → cleaner table).

## Test plan

- [ ] Edit an employee — verify Full Name field is pre-populated and saves correctly
- [ ] With 16+ employees, navigate to page 2 — verify correct records appear
- [ ] Delete an employee (soft delete) — verify card counts decrease correctly
- [ ] Verify "New This Month" count excludes soft-deleted employees
- [ ] Check avatar initials render correctly for single and multi-word names
- [ ] Confirm filter/search still resets paginator to page 1

https://claude.ai/code/session_019zDkBtw5hEjiCQNy85syXk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019zDkBtw5hEjiCQNy85syXk)_