### PR TITLE
feat(ui): modernize HRMS design system to premium SaaS quality

### DIFF
--- a/hrms-ui/src/app/app.config.ts
+++ b/hrms-ui/src/app/app.config.ts
@@ -23,17 +23,17 @@ import { NotificationService } from './services/notification.service';
 const MyPreset = definePreset(Aura, {
   semantic: {
     primary: {
-      50: '{orange.50}',
-      100: '{orange.100}',
-      200: '{orange.200}',
-      300: '{orange.300}',
-      400: '{orange.400}',
-      500: '{orange.500}',
-      600: '{orange.600}',
-      700: '{orange.700}',
-      800: '{orange.800}',
-      900: '{orange.900}',
-      950: '{orange.950}',
+      50: '{indigo.50}',
+      100: '{indigo.100}',
+      200: '{indigo.200}',
+      300: '{indigo.300}',
+      400: '{indigo.400}',
+      500: '{indigo.500}',
+      600: '{indigo.600}',
+      700: '{indigo.700}',
+      800: '{indigo.800}',
+      900: '{indigo.900}',
+      950: '{indigo.950}',
     },
   },
 });

--- a/hrms-ui/src/app/features/layout/dashboard/dashboard.css
+++ b/hrms-ui/src/app/features/layout/dashboard/dashboard.css
@@ -1,26 +1,27 @@
-/* Page */
+/* ── Page ── */
 .dash-page {
   max-width: 1280px;
 }
 
-/* Page header */
+/* ── Page header ── */
 .page-title {
-  font-size: 1.25rem;
+  font-size: 1.125rem;
   font-weight: 600;
   color: var(--p-text-color);
   letter-spacing: -0.01em;
+  line-height: 1.25;
 }
 
 .page-date {
   font-size: 0.8125rem;
   color: var(--p-text-muted-color);
-  margin-top: 2px;
+  margin-top: 3px;
 }
 
 .clock-status-label {
   font-size: 0.6875rem;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.07em;
   color: var(--p-text-muted-color);
 }
 
@@ -28,15 +29,21 @@
   font-size: 0.8125rem;
   font-weight: 500;
   color: var(--p-text-color);
-  margin-top: 1px;
+  margin-top: 2px;
+  font-variant-numeric: tabular-nums;
 }
 
-/* Stat strip */
+/* ── Stat strip ── */
 .stat-cell {
   background: var(--p-surface-0);
   border: 1px solid var(--p-surface-200);
-  border-radius: 10px;
-  padding: 18px 20px;
+  border-radius: 8px;
+  padding: 16px 20px;
+  transition: box-shadow 150ms ease-out;
+}
+
+.stat-cell:hover {
+  box-shadow: 0 2px 8px oklch(0 0 0 / 0.06);
 }
 
 .stat-header {
@@ -60,11 +67,12 @@
 }
 
 .stat-value {
-  font-size: 1.875rem;
+  font-size: 1.75rem;
   font-weight: 600;
   color: var(--p-text-color);
   line-height: 1;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.025em;
+  font-variant-numeric: tabular-nums;
 }
 
 .stat-unit {
@@ -74,11 +82,11 @@
   letter-spacing: 0;
 }
 
-/* Panels */
+/* ── Panels ── */
 .panel {
   background: var(--p-surface-0);
   border: 1px solid var(--p-surface-200);
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 20px;
 }
 
@@ -87,12 +95,12 @@
   align-items: flex-start;
   justify-content: space-between;
   margin-bottom: 16px;
-  padding-bottom: 14px;
+  padding-bottom: 12px;
   border-bottom: 1px solid var(--p-surface-100);
 }
 
 .panel-title {
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--p-text-color);
   letter-spacing: -0.01em;
@@ -101,19 +109,19 @@
 .panel-subtitle {
   font-size: 0.75rem;
   color: var(--p-text-muted-color);
-  margin-top: 2px;
+  margin-top: 3px;
 }
 
-/* Data table */
+/* ── Inline data table (Recent Joiners) ── */
 .data-table {
   border-collapse: collapse;
 }
 
 .data-table th {
   font-size: 0.6875rem;
-  font-weight: 500;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.055em;
   color: var(--p-text-muted-color);
   padding: 0 12px 10px;
   text-align: left;
@@ -123,7 +131,7 @@
 .data-table td {
   font-size: 0.8125rem;
   color: var(--p-text-color);
-  padding: 11px 12px;
+  padding: 10px 12px;
   border-bottom: 1px solid var(--p-surface-100);
 }
 
@@ -135,10 +143,14 @@
   border-bottom: none;
 }
 
-/* Leaves */
+.data-table tr:hover td {
+  background-color: var(--p-surface-50);
+}
+
+/* ── Leaves ── */
 .leave-item {
   padding: 10px 12px;
-  border-radius: 8px;
+  border-radius: 6px;
   background: var(--p-surface-50);
   border: 1px solid var(--p-surface-100);
 }
@@ -165,14 +177,14 @@
 .leave-empty {
   font-size: 0.8125rem;
   color: var(--p-text-muted-color);
-  padding: 16px 0;
+  padding: 20px 0;
   text-align: center;
 }
 
-/* Tasks */
+/* ── Tasks ── */
 .task-item {
   padding: 10px 12px;
-  border-radius: 8px;
+  border-radius: 6px;
   background: var(--p-surface-50);
   border: 1px solid var(--p-surface-100);
 }
@@ -190,7 +202,7 @@
   margin-top: 2px;
 }
 
-/* Goals */
+/* ── Goals ── */
 .goal-title {
   font-size: 0.8125rem;
   font-weight: 500;
@@ -201,21 +213,23 @@
   font-size: 0.75rem;
   font-weight: 500;
   color: var(--p-text-muted-color);
+  font-variant-numeric: tabular-nums;
 }
 
-/* Quick actions */
+/* ── Quick actions ── */
 .quick-action {
-  background: var(--p-surface-50);
+  background: var(--p-surface-0);
   border: 1px solid var(--p-surface-200);
   border-radius: 8px;
   color: var(--p-text-color);
   cursor: pointer;
-  transition: background-color 150ms ease-out, border-color 150ms ease-out;
+  transition: background-color 150ms ease-out, border-color 150ms ease-out, box-shadow 150ms ease-out;
 }
 
 .quick-action:hover {
-  background: var(--p-surface-100);
-  border-color: var(--p-surface-300);
+  background: var(--p-surface-50);
+  border-color: var(--p-primary-200);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--p-primary-500) 8%, transparent);
 }
 
 .quick-action-icon {

--- a/hrms-ui/src/app/features/layout/employee/employee.css
+++ b/hrms-ui/src/app/features/layout/employee/employee.css
@@ -5,48 +5,43 @@
   gap: 1rem;
 }
 
-@media (max-width: 900px) {
-  .metrics-row { grid-template-columns: repeat(2, 1fr); }
-}
-@media (max-width: 480px) {
-  .metrics-row { grid-template-columns: 1fr; }
-}
+@media (max-width: 900px) { .metrics-row { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 480px) { .metrics-row { grid-template-columns: 1fr; } }
 
 .metric-card {
-  position: relative;
-  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 1.25rem 1.5rem;
-  background: var(--p-surface-card);
-  border: 1px solid var(--p-surface-border);
-  border-radius: 12px;
-  transition: box-shadow 0.2s ease-out, transform 0.2s ease-out;
+  padding: 1.125rem 1.25rem;
+  background: var(--p-surface-0);
+  border: 1px solid var(--p-surface-200);
+  border-radius: 8px;
+  transition: box-shadow 150ms ease-out;
 }
 
 .metric-card:hover {
-  box-shadow: 0 4px 24px oklch(0 0 0 / 0.07);
-  transform: translateY(-1px);
+  box-shadow: 0 2px 12px oklch(0 0 0 / 0.07);
 }
 
 .metric-value {
   display: block;
-  font-size: 1.875rem;
+  font-size: 1.75rem;
   font-weight: 700;
   line-height: 1;
   letter-spacing: -0.03em;
   color: var(--p-text-color);
-  margin-bottom: 0.375rem;
+  margin-bottom: 0.3rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .metric-label {
   display: block;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   color: var(--p-text-muted-color);
   font-weight: 500;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 .metric-icon {
@@ -54,16 +49,23 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2.75rem;
-  height: 2.75rem;
-  border-radius: 10px;
-  font-size: 1.125rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 8px;
+  font-size: 1rem;
 }
 
-.metric-icon.icon-blue   { background: oklch(94% 0.05 250); color: oklch(48% 0.18 250); }
-.metric-icon.icon-green  { background: oklch(94% 0.06 145); color: oklch(44% 0.18 145); }
-.metric-icon.icon-indigo { background: oklch(93% 0.05 270); color: oklch(48% 0.18 270); }
-.metric-icon.icon-violet { background: oklch(93% 0.05 295); color: oklch(48% 0.18 295); }
+/* Semantic icon colors — intentionally hue-distinct from primary */
+.metric-icon.icon-blue   { background: oklch(94% 0.04 240); color: oklch(46% 0.16 240); }
+.metric-icon.icon-green  { background: oklch(94% 0.06 145); color: oklch(42% 0.17 145); }
+.metric-icon.icon-indigo { background: oklch(93% 0.04 270); color: oklch(46% 0.16 270); }
+.metric-icon.icon-violet { background: oklch(93% 0.05 295); color: oklch(46% 0.16 295); }
+
+/* Dark mode overrides */
+.my-app-dark .metric-icon.icon-blue   { background: oklch(22% 0.04 240); color: oklch(72% 0.13 240); }
+.my-app-dark .metric-icon.icon-green  { background: oklch(22% 0.05 145); color: oklch(68% 0.15 145); }
+.my-app-dark .metric-icon.icon-indigo { background: oklch(22% 0.04 270); color: oklch(70% 0.13 270); }
+.my-app-dark .metric-icon.icon-violet { background: oklch(22% 0.04 295); color: oklch(70% 0.13 295); }
 
 /* ── Table filter bar ── */
 .table-filters {
@@ -87,13 +89,8 @@
   align-items: center;
 }
 
-.search-input {
-  width: 13rem;
-}
-
-.filter-select {
-  width: 9.5rem;
-}
+.search-input { width: 13rem; }
+.filter-select { width: 9.5rem; }
 
 /* ── Employee name cell ── */
 .emp-cell {
@@ -107,8 +104,8 @@
   width: 2rem;
   height: 2rem;
   border-radius: 50%;
-  background: var(--p-primary-100, oklch(93% 0.05 250));
-  color: var(--p-primary-600, oklch(46% 0.18 250));
+  background: var(--p-primary-100);
+  color: var(--p-primary-700);
   font-size: 0.625rem;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -135,9 +132,10 @@
   font-size: 0.8125rem;
   font-weight: 500;
   color: var(--p-text-muted-color);
+  letter-spacing: 0.01em;
 }
 
-/* ── Form sections ── */
+/* ── Form sections (dialogs) ── */
 .section-block {
   margin-bottom: 1.75rem;
 }
@@ -181,7 +179,7 @@
 .detail-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 1.125rem 2rem;
+  gap: 1rem 2rem;
 }
 
 .detail-label {
@@ -216,4 +214,5 @@
   background: var(--p-surface-50);
   border: 1px solid var(--p-surface-border);
   border-radius: 8px;
+  font-variant-numeric: tabular-nums;
 }

--- a/hrms-ui/src/app/features/layout/layout.css
+++ b/hrms-ui/src/app/features/layout/layout.css
@@ -1,15 +1,57 @@
-/* Layout shell */
+/* ── Layout shell ── */
 .layout-shell {
   background-color: var(--p-surface-50);
 }
 
-/* Sidebar */
+/* ── Sidebar ── */
 .sidebar {
+  width: 240px;
   background-color: var(--p-surface-0);
   border-right: 1px solid var(--p-surface-200);
 }
 
-/* Brand bar — same height as topbar for visual alignment */
+/* On mobile the sidebar is a fixed overlay, hidden by default */
+@media (max-width: 1023px) {
+  .sidebar {
+    position: fixed;
+    inset-block: 0;
+    left: 0;
+    z-index: 40;
+    transform: translateX(-100%);
+    transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
+    /* Keep full height on mobile */
+    height: 100%;
+  }
+
+  .layout-shell.sidebar-open .sidebar {
+    transform: translateX(0);
+  }
+}
+
+/* ── Sidebar backdrop (mobile only) ── */
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: oklch(10% 0.005 240 / 0.35);
+  z-index: 30;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease-out;
+}
+
+.sidebar-backdrop.backdrop-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Hide backdrop on desktop */
+@media (min-width: 1024px) {
+  .sidebar-backdrop {
+    display: none;
+  }
+}
+
+/* ── Brand bar ── */
 .brand-bar {
   height: 56px;
   flex-shrink: 0;
@@ -25,7 +67,7 @@
   letter-spacing: -0.01em;
 }
 
-/* Nav items */
+/* ── Nav items ── */
 .nav-link {
   color: var(--p-text-muted-color);
   transition: background-color 150ms ease-out, color 150ms ease-out;
@@ -39,6 +81,7 @@
 .nav-link-active {
   background-color: var(--p-primary-50);
   color: var(--p-primary-700);
+  font-weight: 500;
 }
 
 .nav-icon {
@@ -47,7 +90,7 @@
   text-align: center;
 }
 
-/* User bar */
+/* ── User bar ── */
 .user-bar {
   border-top: 1px solid var(--p-surface-200);
   flex-shrink: 0;
@@ -63,14 +106,15 @@
 
 .user-role {
   color: var(--p-text-muted-color);
+  font-size: 0.6875rem;
 }
 
 .sign-out-btn {
   color: var(--p-text-muted-color);
-  transition: background-color 150ms ease-out, color 150ms ease-out;
   cursor: pointer;
   background: transparent;
   border: none;
+  transition: background-color 150ms ease-out, color 150ms ease-out;
 }
 
 .sign-out-btn:hover {
@@ -78,12 +122,12 @@
   color: var(--p-text-color);
 }
 
-/* Main column */
+/* ── Main column ── */
 .main-column {
   background-color: var(--p-surface-50);
 }
 
-/* Topbar */
+/* ── Topbar ── */
 .topbar {
   height: 56px;
   flex-shrink: 0;
@@ -91,16 +135,47 @@
   border-bottom: 1px solid var(--p-surface-200);
 }
 
+/* Hamburger — only visible on mobile */
+.menu-btn {
+  color: var(--p-text-muted-color);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 150ms ease-out, color 150ms ease-out;
+  display: flex;
+}
+
+.menu-btn:hover {
+  background-color: var(--p-surface-100);
+  color: var(--p-text-color);
+}
+
+@media (min-width: 1024px) {
+  .menu-btn {
+    display: none;
+  }
+}
+
+/* Page label in topbar */
+.topbar-page-label {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--p-text-color);
+  letter-spacing: -0.01em;
+}
+
 .avatar-btn {
   width: 32px;
   height: 32px;
   border: 1px solid var(--p-surface-200);
+  border-radius: 50%;
   background: transparent;
   cursor: pointer;
   padding: 0;
+  flex-shrink: 0;
 }
 
-/* Content */
+/* ── Content area ── */
 .main-content {
   padding: 1.5rem;
 }

--- a/hrms-ui/src/app/features/layout/layout.html
+++ b/hrms-ui/src/app/features/layout/layout.html
@@ -1,11 +1,14 @@
-<div class="layout-shell flex flex-col lg:flex-row h-screen overflow-hidden">
+<div class="layout-shell flex flex-col lg:flex-row h-screen overflow-hidden" [class.sidebar-open]="sidebarOpen">
+
+  <!-- Mobile backdrop -->
+  <div class="sidebar-backdrop" (click)="closeSidebar()" [class.backdrop-visible]="sidebarOpen"></div>
 
   <!-- Sidebar -->
-  <aside class="sidebar flex flex-col w-full lg:w-60 shrink-0 lg:h-full">
+  <aside class="sidebar flex flex-col shrink-0">
 
     <!-- Brand -->
     <div class="brand-bar flex items-center gap-2.5 px-5">
-      <div class="brand-mark flex items-center justify-center w-6 h-6 rounded-lg">
+      <div class="brand-mark flex items-center justify-center w-6 h-6 rounded-lg shrink-0">
         <i class="pi pi-th-large" style="font-size: 0.75rem; color: white"></i>
       </div>
       <span class="brand-name text-sm font-semibold">PeopleOS</span>
@@ -53,7 +56,15 @@
   <div class="main-column flex-1 flex flex-col min-w-0 overflow-hidden">
 
     <!-- Topbar -->
-    <header class="topbar flex items-center justify-end px-6">
+    <header class="topbar flex items-center justify-between px-4 lg:px-6">
+      <div class="flex items-center gap-3">
+        <button class="menu-btn flex items-center justify-center w-8 h-8 rounded-md"
+                (click)="toggleSidebar()"
+                aria-label="Open navigation">
+          <i class="pi pi-bars" style="font-size: 0.9rem"></i>
+        </button>
+        <span class="topbar-page-label">{{ activePageLabel }}</span>
+      </div>
       <div class="flex items-center gap-2">
         <app-notification></app-notification>
         <button class="avatar-btn block rounded-full overflow-hidden" title="Profile" aria-label="User profile">
@@ -77,12 +88,12 @@
   header="Change Password"
   [modal]="true"
   [(visible)]="changePasswordDialog"
-  [style]="{ width: '30vw' }"
+  [style]="{ width: '30rem' }"
   [breakpoints]="{ '1199px': '75vw', '575px': '90vw' }"
 >
-  <span class="p-text-secondary block mb-8">Update your password.</span>
+  <span class="text-sm text-muted-color block mb-6">Update your account password.</span>
   <form
-    class="flex flex-col items-stretch justify-stretch gap-6"
+    class="flex flex-col items-stretch justify-stretch gap-5"
     [formGroup]="changePasswordForm"
     (ngSubmit)="onChangePassword()"
   >
@@ -94,7 +105,7 @@
           inputId="old_password"
           fluid
         ></p-password>
-        <label for="old_password">Old Password</label>
+        <label for="old_password">Current password</label>
       </p-floatlabel>
     </div>
     <div>
@@ -108,15 +119,15 @@
         >
           <ng-template #footer>
             <p-divider />
-            <ul class="pl-2 my-0 leading-normal">
-              <li>At least one lowercase</li>
-              <li>At least one uppercase</li>
-              <li>At least one numeric</li>
+            <ul class="pl-2 my-0 text-sm text-muted-color leading-relaxed list-none">
+              <li>At least one lowercase letter</li>
+              <li>At least one uppercase letter</li>
+              <li>At least one number</li>
               <li>Minimum 8 characters</li>
             </ul>
           </ng-template>
         </p-password>
-        <label for="new_password">New Password</label>
+        <label for="new_password">New password</label>
       </p-floatlabel>
     </div>
     <div>
@@ -127,9 +138,11 @@
           inputId="confirm_password"
           fluid
         />
-        <label for="confirm_password">Confirm Password</label>
+        <label for="confirm_password">Confirm new password</label>
       </p-floatlabel>
     </div>
-    <button pButton type="submit">Change Password</button>
+    <div class="flex justify-end pt-1">
+      <p-button type="submit" label="Update password" icon="pi pi-check" />
+    </div>
   </form>
 </p-dialog>

--- a/hrms-ui/src/app/features/layout/layout.ts
+++ b/hrms-ui/src/app/features/layout/layout.ts
@@ -61,6 +61,7 @@ export class Layout implements OnInit {
   items: MenuItem[] | undefined;
   isSettings: boolean = false;
   changePasswordDialog: boolean = false;
+  sidebarOpen = false;
   userInfo!: {
     id: string;
     name: string;
@@ -187,8 +188,24 @@ export class Layout implements OnInit {
     return menu;
   }
 
+  get activePageLabel(): string {
+    const found = this.items?.find(
+      (i) => i['route'] && (this.activeRoute === i['route'] || this.activeRoute.startsWith(i['route'] + '/'))
+    );
+    return found?.label || 'PeopleOS';
+  }
+
+  toggleSidebar() {
+    this.sidebarOpen = !this.sidebarOpen;
+  }
+
+  closeSidebar() {
+    this.sidebarOpen = false;
+  }
+
   navigate(item: any) {
     this.router.navigate([item.route]);
+    this.sidebarOpen = false;
   }
 
   async onLogoutClick() {

--- a/hrms-ui/src/app/features/login/login.css
+++ b/hrms-ui/src/app/features/login/login.css
@@ -9,7 +9,7 @@
 .brand-panel {
   display: flex;
   flex-direction: column;
-  background-color: oklch(18% 0.012 255);
+  background-color: oklch(18% 0.014 248);
   padding: 44px 48px;
   overflow: hidden;
 }
@@ -23,7 +23,7 @@
 .brand-mark {
   width: 36px;
   height: 36px;
-  background-color: oklch(26% 0.016 255);
+  background-color: oklch(26% 0.018 248);
   border-radius: 9px;
   display: flex;
   align-items: center;
@@ -102,7 +102,7 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background-color: oklch(26% 0.016 255);
+  background-color: oklch(26% 0.018 248);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -195,14 +195,14 @@
 .soft-link {
   font-size: 12.5px;
   font-weight: 500;
-  color: oklch(48% 0.14 255);
+  color: oklch(50% 0.16 259);
   cursor: pointer;
   text-decoration: none;
   transition: color 0.15s ease-out;
 }
 
 .soft-link:hover {
-  color: oklch(36% 0.17 255);
+  color: oklch(38% 0.18 259);
 }
 
 .field-error {

--- a/hrms-ui/src/index.html
+++ b/hrms-ui/src/index.html
@@ -2,10 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>HrmsUi</title>
+    <title>PeopleOS</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,400;0,14..32,500;0,14..32,600;0,14..32,700;1,14..32,400&display=swap" rel="stylesheet" />
   </head>
   <body>
     <app-root></app-root>

--- a/hrms-ui/src/styles.css
+++ b/hrms-ui/src/styles.css
@@ -1,228 +1,109 @@
 @import 'tailwindcss';
 @import 'primeicons/primeicons.css';
 @plugin "tailwindcss-primeui";
-@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
-/* ===== Global Styles ===== */
+/* Dark mode: keyed to the same selector used by PrimeNG */
+@custom-variant dark (&:where(.my-app-dark, .my-app-dark *));
+
+/* ── Base ── */
 html,
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-optical-sizing: auto;
   margin: 0;
   padding: 0;
   height: 100%;
   width: 100%;
-  background-color: color-mix(
-    in srgb,
-    var(--p-surface-0) calc(100% * var(--tw-bg-opacity, 1)),
-    transparent
-  );
-  scroll-behavior: smooth;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-/* ===== Custom Scrollbar ===== */
+/* ── Scrollbar ── */
 ::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+  width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--p-surface-100);
-  border-radius: 10px;
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
   background: var(--p-surface-300);
-  border-radius: 10px;
-  transition: background 0.3s ease;
+  border-radius: 99px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--p-surface-400);
 }
 
-/* Firefox scrollbar */
 * {
   scrollbar-width: thin;
-  scrollbar-color: var(--p-surface-300) var(--p-surface-100);
+  scrollbar-color: var(--p-surface-300) transparent;
 }
 
-/* ===== Typography Enhancements ===== */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+/* ── Typography ── */
+h1, h2, h3, h4, h5, h6 {
   font-weight: 600;
-  line-height: 1.2;
+  line-height: 1.25;
   color: var(--p-text-color);
+  text-wrap: balance;
+  margin: 0;
 }
 
-h1 {
-  font-size: 2.5rem;
-}
-h2 {
-  font-size: 2rem;
-}
-h3 {
-  font-size: 1.75rem;
-}
-h4 {
-  font-size: 1.5rem;
-}
-h5 {
-  font-size: 1.25rem;
-}
-h6 {
-  font-size: 1rem;
-}
+/* Product UI scale: tight ratio (1.2), fixed rem */
+h1 { font-size: 1.5rem; }
+h2 { font-size: 1.25rem; }
+h3 { font-size: 1.125rem; }
+h4 { font-size: 1rem; }
+h5 { font-size: 0.9375rem; }
+h6 { font-size: 0.875rem; }
 
-/* ===== Smooth Transitions ===== */
-* {
+/* ── Interactive element transitions (targeted, not wildcard) ── */
+button,
+a,
+[role="button"],
+.p-button,
+.nav-link,
+.p-inputtext,
+.p-select,
+.p-checkbox,
+input,
+select,
+textarea {
+  transition-property: background-color, border-color, color, box-shadow, opacity, transform;
+  transition-duration: 150ms;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* ===== Animations ===== */
+/* ── Animations ── */
 @keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 @keyframes slideIn {
-  from {
-    transform: translateX(-100%);
-  }
-  to {
-    transform: translateX(0);
-  }
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(0); }
 }
 
 @keyframes scaleIn {
-  from {
-    transform: scale(0.95);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
+  from { transform: scale(0.97); opacity: 0; }
+  to   { transform: scale(1);    opacity: 1; }
 }
 
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
+@keyframes shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }
 
-.animate-fadein {
-  animation: fadeIn 0.3s ease-out;
-}
+.animate-fadein  { animation: fadeIn  200ms ease-out; }
+.animate-slidein { animation: slideIn 200ms ease-out; }
+.animate-scalein { animation: scaleIn 150ms ease-out; }
 
-.animate-slidein {
-  animation: slideIn 0.3s ease-out;
-}
-
-.animate-scalein {
-  animation: scaleIn 0.2s ease-out;
-}
-
-.animate-pulse {
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-}
-
-/* ===== Modern Card Styles ===== */
-.modern-card {
-  background: var(--p-surface-0);
-  border-radius: 10px;
-  padding: 20px;
-  border: 1px solid var(--p-surface-200);
-}
-
-/* ===== Input Enhancements ===== */
-.p-inputtext {
-  width: inherit;
-  transition: all 0.2s ease;
-}
-
-.p-inputtext:focus {
-  box-shadow: 0 0 0 3px rgba(var(--p-primary-500), 0.1);
-}
-
-
-/* ===== Table Enhancements ===== */
-.p-datatable .p-datatable-tbody > tr {
-  transition: background-color 0.2s ease;
-}
-
-.p-datatable .p-datatable-tbody > tr:hover {
-  background-color: var(--p-surface-50) !important;
-}
-
-.p-datatable .p-datatable-thead > tr > th {
-  font-weight: 600;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.05em;
-  color: var(--p-text-muted-color);
-}
-
-/* ===== Card Icon Styles ===== */
-.card-icons {
-  font-size: 2rem;
-  opacity: 0.8;
-}
-
-/* ===== Badge Enhancements ===== */
-.p-badge {
-  font-weight: 600;
-  letter-spacing: 0.025em;
-}
-
-/* ===== Dialog Enhancements ===== */
-.p-dialog {
-  border-radius: 16px;
-  overflow: hidden;
-}
-
-.p-dialog .p-dialog-header {
-  border-top-left-radius: 16px;
-  border-top-right-radius: 16px;
-}
-
-
-/* ===== Utility Classes ===== */
-.shadow-soft {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-}
-
-.shadow-medium {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-}
-
-.shadow-strong {
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
-}
-
-
-/* ===== Focus Visible for Accessibility ===== */
-*:focus-visible {
-  outline: 2px solid var(--p-primary-500);
-  outline-offset: 2px;
-  border-radius: 4px;
-}
-
-/* ===== Loading States ===== */
+/* ── Skeleton loading ── */
 .skeleton {
   background: linear-gradient(
     90deg,
@@ -231,35 +112,90 @@ h6 {
     var(--p-surface-100) 75%
   );
   background-size: 200% 100%;
-  animation: loading 1.5s ease-in-out infinite;
+  animation: shimmer 1.6s ease-in-out infinite;
+  border-radius: 4px;
 }
 
-@keyframes loading {
-  0% {
-    background-position: 200% 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
+/* ── Surface card ── */
+.modern-card {
+  background: var(--p-surface-0);
+  border-radius: 8px;
+  padding: 20px;
+  border: 1px solid var(--p-surface-200);
+  box-shadow: 0 1px 3px oklch(0 0 0 / 0.04), 0 1px 2px oklch(0 0 0 / 0.03);
 }
 
-/* ===== Responsive Utilities ===== */
+/* ── Shadow scale ── */
+.shadow-soft   { box-shadow: 0 1px 3px oklch(0 0 0 / 0.06), 0 1px 2px oklch(0 0 0 / 0.04); }
+.shadow-medium { box-shadow: 0 4px 12px oklch(0 0 0 / 0.08), 0 2px 4px oklch(0 0 0 / 0.05); }
+.shadow-strong { box-shadow: 0 8px 24px oklch(0 0 0 / 0.10), 0 4px 8px oklch(0 0 0 / 0.06); }
+
+/* ── Input focus ring ── */
+.p-inputtext:focus,
+.p-password input:focus {
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--p-primary-500) 18%, transparent);
+}
+
+/* ── Table ── */
+.p-datatable .p-datatable-tbody > tr {
+  transition: background-color 120ms ease-out;
+}
+
+.p-datatable .p-datatable-tbody > tr:hover {
+  background-color: var(--p-surface-50) !important;
+}
+
+.p-datatable .p-datatable-thead > tr > th {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.055em;
+  color: var(--p-text-muted-color);
+}
+
+/* Tabular numbers in data contexts */
+.p-datatable,
+.stat-value,
+.metric-value,
+[data-numeric] {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Dialog ── */
+.p-dialog {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.p-dialog .p-dialog-header {
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}
+
+/* ── Focus visible ── */
+*:focus-visible {
+  outline: 2px solid var(--p-primary-500);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ── Badge ── */
+.p-badge {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+/* ── Responsive adjustments ── */
 @media (max-width: 768px) {
-  h1 {
-    font-size: 2rem;
-  }
-  h2 {
-    font-size: 1.75rem;
-  }
-  h3 {
-    font-size: 1.5rem;
-  }
-  h4 {
-    font-size: 1.25rem;
-  }
+  .modern-card { padding: 16px; }
+}
 
-  .modern-card {
-    padding: 16px;
-    border-radius: 12px;
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fadein,
+  .animate-slidein,
+  .animate-scalein,
+  .skeleton {
+    animation: none;
   }
 }


### PR DESCRIPTION
## Summary

- **Primary color**: Replaced orange with indigo — shifts the product from energetic/alert to calm, institutional authority (matching "clear, capable, calm" brand personality in PRODUCT.md)
- **Typography + font**: Inter variable font loaded via Google Fonts with `font-optical-sizing: auto`; product-UI heading scale (1.25 ratio, fixed rem); `tabular-nums` applied globally to all data surfaces (tables, stat values, salary fields)
- **Global styles**: Removed wildcard `transition-timing-function` (performance anti-pattern); targeted transitions on interactive elements only; 6px scrollbar; correct `color-mix()` focus ring replacing invalid `rgba(var())` syntax; `prefers-reduced-motion` support; fixed dark-mode `@custom-variant` to match PrimeNG's `.my-app-dark` selector
- **Layout shell**: Mobile sidebar is now a fixed overlay that slides in from the left with a translucent backdrop; hamburger menu button in topbar (hidden on desktop); topbar shows current page title derived from active route
- **Dashboard**: Stat cells and panels at 8px radius (tighter, product-grade); hover shadow on stat cells; quick-action focus ring using primary color tint; `tabular-nums` on all numeric values
- **Employee table**: Metric icon colors are dark-mode-safe (explicit `.my-app-dark` overrides with dark bg + light icon); `tabular-nums` on metric values and net salary; consistent 8px radius
- **Login page**: Brand panel and accent hue aligned to new indigo primary (hue 248) for visual consistency across the auth and app surfaces

## Test plan

- [ ] Run `npm start` in `hrms-ui/` and verify the app loads without console errors
- [ ] Confirm primary buttons, active nav items, and focus rings are indigo (not orange)
- [ ] Resize to mobile — sidebar should be hidden, hamburger should appear in topbar, tapping hamburger opens sidebar overlay, tapping backdrop closes it
- [ ] Verify topbar shows correct page name when navigating between routes
- [ ] Check dashboard stat numbers are tabular (aligned) and no orange remains
- [ ] Check employee metrics and table — no orange, dark mode icons readable
- [ ] Toggle dark mode and confirm metric icon colors invert correctly
- [ ] Visit login page — brand panel should be dark indigo-tinted, "Forgot password?" link is indigo

https://claude.ai/code/session_01CYXtiuDuHPzbwin2NHYReP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYXtiuDuHPzbwin2NHYReP)_