### PR TITLE
Refactor dashboard metrics pipeline and harden summary model

### DIFF
--- a/hrms-backend/src/controllers/dashboard.controller.ts
+++ b/hrms-backend/src/controllers/dashboard.controller.ts
@@ -3,8 +3,111 @@ import { SUCCESS_CODES } from '../utils/response-codes';
 import { successResponse } from '../utils/response-helper';
 import { prisma } from '../lib/prisma';
 
-const todayStart = () => new Date(new Date().setHours(0, 0, 0, 0));
-const todayEnd = () => new Date(new Date().setHours(23, 59, 59, 999));
+const dayRangeUtc = (date = new Date()) => {
+  const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0));
+  const end = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999));
+  return { start, end };
+};
+
+const monthRangeUtc = (date = new Date()) => {
+  const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+  return { start, end };
+};
+
+const getTodayPresentCount = async (employeeIds?: string[]) => {
+  const { start, end } = dayRangeUtc();
+  const grouped = await prisma.attendance.groupBy({
+    by: ['employeeId'],
+    where: {
+      attendanceDate: { gte: start, lte: end },
+      ...(employeeIds ? { employeeId: { in: employeeIds } } : {}),
+    },
+  });
+
+  return grouped.length;
+};
+
+const getAdminStats = async () => {
+  const [totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners] =
+    await Promise.all([
+      prisma.employee.count({ where: { status: 'ACTIVE' } }),
+      prisma.department.count(),
+      prisma.leave.count({ where: { status: 'PENDING' } }),
+      getTodayPresentCount(),
+      prisma.employee.findMany({
+        where: { status: 'ACTIVE' },
+        orderBy: { joiningDate: 'desc' },
+        take: 5,
+        include: {
+          user: { select: { name: true, email: true } },
+          designation: { select: { name: true } },
+        },
+      }),
+    ]);
+
+  return { totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners };
+};
+
+const getHrStats = async () => {
+  const currentDate = new Date();
+  const [totalEmployees, pendingLeaves, todayAttendance, processedPayrollsForCurrentMonth] =
+    await Promise.all([
+      prisma.employee.count({ where: { status: 'ACTIVE' } }),
+      prisma.leave.count({ where: { status: 'PENDING' } }),
+      getTodayPresentCount(),
+      prisma.payroll.count({
+        where: {
+          month: currentDate.getUTCMonth() + 1,
+          year: currentDate.getUTCFullYear(),
+        },
+      }),
+    ]);
+
+  const pendingPayrolls = Math.max(totalEmployees - processedPayrollsForCurrentMonth, 0);
+
+  return { totalEmployees, pendingLeaves, todayAttendance, pendingPayrolls };
+};
+
+const getManagerStats = async (employeeId: string) => {
+  const teamMembers = await prisma.employee.findMany({
+    where: { managerId: employeeId, status: 'ACTIVE' },
+    select: { id: true },
+  });
+
+  const teamIds = teamMembers.map((e) => e.id);
+  if (!teamIds.length) {
+    return { teamSize: 0, teamLeaves: 0, teamAttendance: 0 };
+  }
+
+  const [teamSize, teamLeaves, teamAttendance] = await Promise.all([
+    prisma.employee.count({ where: { id: { in: teamIds }, status: 'ACTIVE' } }),
+    prisma.leave.count({ where: { employeeId: { in: teamIds }, status: 'PENDING' } }),
+    getTodayPresentCount(teamIds),
+  ]);
+
+  return { teamSize, teamLeaves, teamAttendance };
+};
+
+const getEmployeeStats = async (employeeId: string) => {
+  const currentYear = new Date().getUTCFullYear();
+  const { start, end } = monthRangeUtc();
+
+  const [leaveBalance, attendanceSummary] = await Promise.all([
+    prisma.leaveBalance.findFirst({ where: { employeeId, year: currentYear, leaveType: 'ANNUAL' } }),
+    prisma.attendance.count({
+      where: {
+        employeeId,
+        attendanceDate: {
+          gte: start,
+          lt: end,
+        },
+      },
+    }),
+  ]);
+
+  return { leaveBalance, attendanceSummary };
+};
 
 export const getDashboardSummary = async (req: Request, res: Response) => {
   const user = (req as any).user;
@@ -13,78 +116,22 @@ export const getDashboardSummary = async (req: Request, res: Response) => {
   let stats: any = {};
 
   if (role === 'ADMIN') {
-    const [totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners] =
-      await prisma.$transaction([
-        prisma.employee.count({ where: { status: 'ACTIVE' } }),
-        prisma.department.count(),
-        prisma.leave.count({ where: { status: 'PENDING' } }),
-        prisma.attendance.count({
-          where: { attendanceDate: { gte: todayStart(), lt: todayEnd() } },
-        }),
-        prisma.employee.findMany({
-          where: { status: 'ACTIVE' },
-          orderBy: { joiningDate: 'desc' },
-          take: 5,
-          include: {
-            user: { select: { name: true, email: true } },
-            designation: { select: { name: true } },
-          },
-        }),
-      ]);
-
-    stats = { totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners };
+    stats = await getAdminStats();
   } else if (role === 'HR') {
-    const [totalEmployees, pendingLeaves, todayAttendance, pendingPayrolls] =
-      await prisma.$transaction([
-        prisma.employee.count({ where: { status: 'ACTIVE' } }),
-        prisma.leave.count({ where: { status: 'PENDING' } }),
-        prisma.attendance.count({
-          where: { attendanceDate: { gte: todayStart(), lt: todayEnd() } },
-        }),
-        prisma.payroll.count(),
-      ]);
-
-    stats = { totalEmployees, pendingLeaves, todayAttendance, pendingPayrolls };
+    stats = await getHrStats();
   } else if (role === 'MANAGER') {
-    const teamMembers = await prisma.employee.findMany({
-      where: { managerId: employeeId },
-      select: { id: true },
-    });
-    const teamIds = teamMembers.map((e) => e.id);
-
-    const [teamSize, teamLeaves, teamAttendance] = await prisma.$transaction([
-      prisma.employee.count({ where: { managerId: employeeId, status: 'ACTIVE' } }),
-      prisma.leave.count({ where: { employeeId: { in: teamIds }, status: 'PENDING' } }),
-      prisma.attendance.count({
-        where: {
-          employeeId: { in: teamIds },
-          attendanceDate: { gte: todayStart(), lt: todayEnd() },
-        },
-      }),
-    ]);
-
-    stats = { teamSize, teamLeaves, teamAttendance };
+    stats = await getManagerStats(employeeId);
   } else {
-    const [leaveBalance, attendanceSummary] = await prisma.$transaction([
-      prisma.leaveBalance.findFirst({
-        where: { employeeId, year: new Date().getFullYear() },
-      }),
-      prisma.attendance.count({
-        where: {
-          employeeId,
-          attendanceDate: {
-            gte: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
-            lt: todayEnd(),
-          },
-        },
-      }),
-    ]);
-
-    stats = { leaveBalance, attendanceSummary };
+    stats = await getEmployeeStats(employeeId);
   }
 
-  return successResponse(res, stats, 'Dashboard stats fetched successfully', SUCCESS_CODES.SUCCESS, 200);
+  return successResponse(
+    res,
+    stats,
+    'Dashboard stats fetched successfully',
+    SUCCESS_CODES.SUCCESS,
+    200
+  );
 };
 
-// Alias kept for backwards compatibility
 export const getDashboardStats = getDashboardSummary;

--- a/hrms-ui/src/app/features/layout/dashboard/dashboard.ts
+++ b/hrms-ui/src/app/features/layout/dashboard/dashboard.ts
@@ -1,5 +1,5 @@
 import { CommonModule, formatDate } from '@angular/common';
-import { ChangeDetectorRef, Component } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../../services/api-interface.service';
 import { AuthStateService } from '../../../services/auth-state.service';
@@ -11,6 +11,25 @@ import { ChartModule } from 'primeng/chart';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { TagModule } from 'primeng/tag';
 import dayjs from 'dayjs';
+
+interface DashboardSummary {
+  totalEmployees?: number;
+  totalDepartments?: number;
+  pendingLeaves?: number;
+  todayAttendance?: number;
+  pendingPayrolls?: number;
+  teamSize?: number;
+  teamLeaves?: number;
+  teamAttendance?: number;
+  leaveBalance?: { totalLeaves: number; usedLeaves: number } | null;
+  attendanceSummary?: number;
+  recentJoiners?: Array<{
+    user: { name: string; email: string };
+    designation?: { name: string } | null;
+    joiningDate?: string;
+  }>;
+}
+
 
 @Component({
   selector: 'app-dashboard',
@@ -28,7 +47,7 @@ import dayjs from 'dayjs';
   templateUrl: './dashboard.html',
   styleUrl: './dashboard.css',
 })
-export class Dashboard {
+export class Dashboard implements OnInit {
   currentDate = new Date();
   checkInTime = '9:05 AM';
   workingHours = '7h 25m';
@@ -78,14 +97,16 @@ export class Dashboard {
   chartOptions = {};
   userInfo: any;
 
-  dashboardStats: any = {};
+  dashboardStats: DashboardSummary = {};
 
-  constructor(private serverApi: ApiService, private cdr: ChangeDetectorRef, private authState: AuthStateService) {
+  constructor(private serverApi: ApiService, private cdr: ChangeDetectorRef, private authState: AuthStateService) {}
+
+  ngOnInit(): void {
     this.userInfo = this.authState.userInfo;
-    if (this.userInfo && this.userInfo.role) {
+    if (this.userInfo?.role) {
       this.userInfo.role = this.userInfo.role.toUpperCase();
     }
-    console.log('UserInfo:', this.userInfo);
+
     this.initChartOptions();
     this.loadUpcomingLeaves();
     this.loadPerformanceGoals();
@@ -96,7 +117,7 @@ export class Dashboard {
 
   async loadDashboardStats() {
     try {
-      const res: any = await this.serverApi.get('/api/dashboard/summary');
+      const res = await this.serverApi.get<DashboardSummary>('/api/dashboard/summary');
       this.dashboardStats = res;
     } catch (error) {
       console.error('Failed to load dashboard stats', error);
@@ -147,7 +168,7 @@ export class Dashboard {
       ],
     };
     this.cdr.detectChanges();
-    console.log(this.todayStatus, 'status>>>>');
+    
   }
 
   async loadUpcomingLeaves() {
@@ -251,7 +272,7 @@ export class Dashboard {
         },
       },
     };
-    console.log(this.attendanceData, 'chartdata');
+    
     this.cdr.markForCheck();
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure dashboard KPIs are deterministic and correct by centralizing date-window logic and fixing aggregation semantics. 
- Reduce coupling and improve maintainability by separating per-role metric logic from the monolithic controller. 
- Harden the frontend-to-backend contract to prevent runtime shape drift and remove constructor side-effects in the Angular component.

### Description

- Reworked the backend summary controller into role-specific metric builders: `getAdminStats`, `getHrStats`, `getManagerStats`, and `getEmployeeStats` for clearer module boundaries. 
- Introduced UTC time-window helpers `dayRangeUtc` and `monthRangeUtc` to normalize daily and monthly rollups. 
- Fixed attendance KPI to count distinct present employees via `prisma.attendance.groupBy` in `getTodayPresentCount(employeeIds?)` to avoid inflated counts from multiple rows. 
- Corrected HR payroll KPI to compute `pendingPayrolls = active employees - processed payrolls for the current month` instead of using raw `payroll.count()`. 
- Added manager empty-team guard to short-circuit queries when a manager has no direct reports. 
- Strengthened frontend typing by adding a `DashboardSummary` interface and updated the dashboard component to perform bootstrapping in `ngOnInit` instead of the constructor. 
- Removed noisy `console.log` calls from the dashboard frontend to reduce client-side noise.

### Testing

- Ran backend TypeScript check with `npx tsc --noEmit` which succeeded. 
- Ran frontend TypeScript check with `npx tsc -p tsconfig.app.json --noEmit` which succeeded. 
- Attempted to run unit/build test runs (`vitest` / Angular test runner) but the environment failed during application bundle generation and a full Angular test run could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34ac8338c832baf5c7e23c94ab9eb)