### PR TITLE
Refactor dashboard stats to use UTC ranges and role-specific aggregations; tighten UI typing and bindings

### DIFF
--- a/hrms-backend/src/controllers/dashboard.controller.ts
+++ b/hrms-backend/src/controllers/dashboard.controller.ts
@@ -3,8 +3,111 @@ import { SUCCESS_CODES } from '../utils/response-codes';
 import { successResponse } from '../utils/response-helper';
 import { prisma } from '../lib/prisma';
 
-const todayStart = () => new Date(new Date().setHours(0, 0, 0, 0));
-const todayEnd = () => new Date(new Date().setHours(23, 59, 59, 999));
+const dayRangeUtc = (date = new Date()) => {
+  const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0));
+  const end = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999));
+  return { start, end };
+};
+
+const monthRangeUtc = (date = new Date()) => {
+  const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+  return { start, end };
+};
+
+const getTodayPresentCount = async (employeeIds?: string[]) => {
+  const { start, end } = dayRangeUtc();
+  const grouped = await prisma.attendance.groupBy({
+    by: ['employeeId'],
+    where: {
+      attendanceDate: { gte: start, lte: end },
+      ...(employeeIds ? { employeeId: { in: employeeIds } } : {}),
+    },
+  });
+
+  return grouped.length;
+};
+
+const getAdminStats = async () => {
+  const [totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners] =
+    await Promise.all([
+      prisma.employee.count({ where: { status: 'ACTIVE' } }),
+      prisma.department.count(),
+      prisma.leave.count({ where: { status: 'PENDING' } }),
+      getTodayPresentCount(),
+      prisma.employee.findMany({
+        where: { status: 'ACTIVE' },
+        orderBy: { joiningDate: 'desc' },
+        take: 5,
+        include: {
+          user: { select: { name: true, email: true } },
+          designation: { select: { name: true } },
+        },
+      }),
+    ]);
+
+  return { totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners };
+};
+
+const getHrStats = async () => {
+  const currentDate = new Date();
+  const [totalEmployees, pendingLeaves, todayAttendance, processedPayrollsForCurrentMonth] =
+    await Promise.all([
+      prisma.employee.count({ where: { status: 'ACTIVE' } }),
+      prisma.leave.count({ where: { status: 'PENDING' } }),
+      getTodayPresentCount(),
+      prisma.payroll.count({
+        where: {
+          month: currentDate.getUTCMonth() + 1,
+          year: currentDate.getUTCFullYear(),
+        },
+      }),
+    ]);
+
+  const pendingPayrolls = Math.max(totalEmployees - processedPayrollsForCurrentMonth, 0);
+
+  return { totalEmployees, pendingLeaves, todayAttendance, pendingPayrolls };
+};
+
+const getManagerStats = async (employeeId: string) => {
+  const teamMembers = await prisma.employee.findMany({
+    where: { managerId: employeeId, status: 'ACTIVE' },
+    select: { id: true },
+  });
+
+  const teamIds = teamMembers.map((e) => e.id);
+  if (!teamIds.length) {
+    return { teamSize: 0, teamLeaves: 0, teamAttendance: 0 };
+  }
+
+  const [teamSize, teamLeaves, teamAttendance] = await Promise.all([
+    prisma.employee.count({ where: { id: { in: teamIds }, status: 'ACTIVE' } }),
+    prisma.leave.count({ where: { employeeId: { in: teamIds }, status: 'PENDING' } }),
+    getTodayPresentCount(teamIds),
+  ]);
+
+  return { teamSize, teamLeaves, teamAttendance };
+};
+
+const getEmployeeStats = async (employeeId: string) => {
+  const currentYear = new Date().getUTCFullYear();
+  const { start, end } = monthRangeUtc();
+
+  const [leaveBalance, attendanceSummary] = await Promise.all([
+    prisma.leaveBalance.findFirst({ where: { employeeId, year: currentYear, leaveType: 'ANNUAL' } }),
+    prisma.attendance.count({
+      where: {
+        employeeId,
+        attendanceDate: {
+          gte: start,
+          lt: end,
+        },
+      },
+    }),
+  ]);
+
+  return { leaveBalance, attendanceSummary };
+};
 
 export const getDashboardSummary = async (req: Request, res: Response) => {
   const user = (req as any).user;
@@ -13,78 +116,22 @@ export const getDashboardSummary = async (req: Request, res: Response) => {
   let stats: any = {};
 
   if (role === 'ADMIN') {
-    const [totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners] =
-      await prisma.$transaction([
-        prisma.employee.count({ where: { status: 'ACTIVE' } }),
-        prisma.department.count(),
-        prisma.leave.count({ where: { status: 'PENDING' } }),
-        prisma.attendance.count({
-          where: { attendanceDate: { gte: todayStart(), lt: todayEnd() } },
-        }),
-        prisma.employee.findMany({
-          where: { status: 'ACTIVE' },
-          orderBy: { joiningDate: 'desc' },
-          take: 5,
-          include: {
-            user: { select: { name: true, email: true } },
-            designation: { select: { name: true } },
-          },
-        }),
-      ]);
-
-    stats = { totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners };
+    stats = await getAdminStats();
   } else if (role === 'HR') {
-    const [totalEmployees, pendingLeaves, todayAttendance, pendingPayrolls] =
-      await prisma.$transaction([
-        prisma.employee.count({ where: { status: 'ACTIVE' } }),
-        prisma.leave.count({ where: { status: 'PENDING' } }),
-        prisma.attendance.count({
-          where: { attendanceDate: { gte: todayStart(), lt: todayEnd() } },
-        }),
-        prisma.payroll.count(),
-      ]);
-
-    stats = { totalEmployees, pendingLeaves, todayAttendance, pendingPayrolls };
+    stats = await getHrStats();
   } else if (role === 'MANAGER') {
-    const teamMembers = await prisma.employee.findMany({
-      where: { managerId: employeeId },
-      select: { id: true },
-    });
-    const teamIds = teamMembers.map((e) => e.id);
-
-    const [teamSize, teamLeaves, teamAttendance] = await prisma.$transaction([
-      prisma.employee.count({ where: { managerId: employeeId, status: 'ACTIVE' } }),
-      prisma.leave.count({ where: { employeeId: { in: teamIds }, status: 'PENDING' } }),
-      prisma.attendance.count({
-        where: {
-          employeeId: { in: teamIds },
-          attendanceDate: { gte: todayStart(), lt: todayEnd() },
-        },
-      }),
-    ]);
-
-    stats = { teamSize, teamLeaves, teamAttendance };
+    stats = await getManagerStats(employeeId);
   } else {
-    const [leaveBalance, attendanceSummary] = await prisma.$transaction([
-      prisma.leaveBalance.findFirst({
-        where: { employeeId, year: new Date().getFullYear() },
-      }),
-      prisma.attendance.count({
-        where: {
-          employeeId,
-          attendanceDate: {
-            gte: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
-            lt: todayEnd(),
-          },
-        },
-      }),
-    ]);
-
-    stats = { leaveBalance, attendanceSummary };
+    stats = await getEmployeeStats(employeeId);
   }
 
-  return successResponse(res, stats, 'Dashboard stats fetched successfully', SUCCESS_CODES.SUCCESS, 200);
+  return successResponse(
+    res,
+    stats,
+    'Dashboard stats fetched successfully',
+    SUCCESS_CODES.SUCCESS,
+    200
+  );
 };
 
-// Alias kept for backwards compatibility
 export const getDashboardStats = getDashboardSummary;

--- a/hrms-ui/src/app/features/layout/dashboard/dashboard.html
+++ b/hrms-ui/src/app/features/layout/dashboard/dashboard.html
@@ -32,28 +32,28 @@
           <span class="stat-label">Total Employees</span>
           <i class="pi pi-users stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.totalEmployees || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.totalEmployees || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Departments</span>
           <i class="pi pi-sitemap stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.totalDepartments || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.totalDepartments || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Pending Leaves</span>
           <i class="pi pi-calendar-times stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.pendingLeaves || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.pendingLeaves || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Present Today</span>
           <i class="pi pi-check-circle stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.todayAttendance || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.todayAttendance || 0 }}</p>
       </div>
     </ng-container>
 
@@ -64,28 +64,28 @@
           <span class="stat-label">Total Employees</span>
           <i class="pi pi-users stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.totalEmployees || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.totalEmployees || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Pending Leaves</span>
           <i class="pi pi-calendar-times stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.pendingLeaves || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.pendingLeaves || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Attendance Today</span>
           <i class="pi pi-check-circle stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.todayAttendance || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.todayAttendance || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Pending Payrolls</span>
           <i class="pi pi-dollar stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.pendingPayrolls || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.pendingPayrolls || 0 }}</p>
       </div>
     </ng-container>
 
@@ -96,21 +96,21 @@
           <span class="stat-label">Team Size</span>
           <i class="pi pi-users stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.teamSize || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.teamSize || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Pending Leaves</span>
           <i class="pi pi-calendar-times stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.teamLeaves || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.teamLeaves || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Present Today</span>
           <i class="pi pi-check-circle stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.teamAttendance || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.teamAttendance || 0 }}</p>
       </div>
     </ng-container>
 
@@ -129,7 +129,7 @@
           <i class="pi pi-calendar stat-icon"></i>
         </div>
         <p class="stat-value">
-          {{ (dashboardStats?.leaveBalance?.totalLeaves - dashboardStats?.leaveBalance?.usedLeaves) || 0 }}<span class="stat-unit"> days</span>
+          {{ leaveBalanceDaysRemaining }}<span class="stat-unit"> days</span>
         </p>
       </div>
     </ng-container>
@@ -170,7 +170,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let employee of dashboardStats?.recentJoiners">
+          <tr *ngFor="let employee of dashboardStats.recentJoiners">
             <td class="font-medium">{{ employee.user.name }}</td>
             <td>{{ employee.user.email }}</td>
             <td>{{ employee.designation?.name || 'N/A' }}</td>

--- a/hrms-ui/src/app/features/layout/dashboard/dashboard.ts
+++ b/hrms-ui/src/app/features/layout/dashboard/dashboard.ts
@@ -1,5 +1,5 @@
 import { CommonModule, formatDate } from '@angular/common';
-import { ChangeDetectorRef, Component } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../../services/api-interface.service';
 import { AuthStateService } from '../../../services/auth-state.service';
@@ -11,6 +11,25 @@ import { ChartModule } from 'primeng/chart';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { TagModule } from 'primeng/tag';
 import dayjs from 'dayjs';
+
+interface DashboardSummary {
+  totalEmployees?: number;
+  totalDepartments?: number;
+  pendingLeaves?: number;
+  todayAttendance?: number;
+  pendingPayrolls?: number;
+  teamSize?: number;
+  teamLeaves?: number;
+  teamAttendance?: number;
+  leaveBalance?: { totalLeaves: number; usedLeaves: number } | null;
+  attendanceSummary?: number;
+  recentJoiners?: Array<{
+    user: { name: string; email: string };
+    designation?: { name: string } | null;
+    joiningDate?: string;
+  }>;
+}
+
 
 @Component({
   selector: 'app-dashboard',
@@ -28,7 +47,7 @@ import dayjs from 'dayjs';
   templateUrl: './dashboard.html',
   styleUrl: './dashboard.css',
 })
-export class Dashboard {
+export class Dashboard implements OnInit {
   currentDate = new Date();
   checkInTime = '9:05 AM';
   workingHours = '7h 25m';
@@ -78,14 +97,16 @@ export class Dashboard {
   chartOptions = {};
   userInfo: any;
 
-  dashboardStats: any = {};
+  dashboardStats: DashboardSummary = {};
 
-  constructor(private serverApi: ApiService, private cdr: ChangeDetectorRef, private authState: AuthStateService) {
+  constructor(private serverApi: ApiService, private cdr: ChangeDetectorRef, private authState: AuthStateService) {}
+
+  ngOnInit(): void {
     this.userInfo = this.authState.userInfo;
-    if (this.userInfo && this.userInfo.role) {
+    if (this.userInfo?.role) {
       this.userInfo.role = this.userInfo.role.toUpperCase();
     }
-    console.log('UserInfo:', this.userInfo);
+
     this.initChartOptions();
     this.loadUpcomingLeaves();
     this.loadPerformanceGoals();
@@ -94,9 +115,14 @@ export class Dashboard {
     this.loadDashboardStats();
   }
 
+
+  get leaveBalanceDaysRemaining(): number {
+    if (!this.dashboardStats.leaveBalance) return 0;
+    return this.dashboardStats.leaveBalance.totalLeaves - this.dashboardStats.leaveBalance.usedLeaves;
+  }
   async loadDashboardStats() {
     try {
-      const res: any = await this.serverApi.get('/api/dashboard/summary');
+      const res = await this.serverApi.get<DashboardSummary>('/api/dashboard/summary');
       this.dashboardStats = res;
     } catch (error) {
       console.error('Failed to load dashboard stats', error);
@@ -147,7 +173,7 @@ export class Dashboard {
       ],
     };
     this.cdr.detectChanges();
-    console.log(this.todayStatus, 'status>>>>');
+    
   }
 
   async loadUpcomingLeaves() {
@@ -251,7 +277,7 @@ export class Dashboard {
         },
       },
     };
-    console.log(this.attendanceData, 'chartdata');
+    
     this.cdr.markForCheck();
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure daily and monthly attendance/payroll calculations are consistent across timezones by using UTC-based date ranges.
- Improve clarity and maintainability by extracting role-specific dashboard aggregation logic into separate functions.
- Make the UI more type-safe and reliable by adding an interface for dashboard data and a dedicated leave-balance getter.

### Description
- Introduced `dayRangeUtc` and `monthRangeUtc` helpers and replaced local-date logic with UTC-aware ranges in the dashboard controller.
- Replaced monolithic controller logic with role-specific functions `getAdminStats`, `getHrStats`, `getManagerStats`, and `getEmployeeStats`, and added `getTodayPresentCount` which uses `prisma.attendance.groupBy` to count unique present employees.
- Adjusted payroll counting to use UTC month and year, restricted employee leave balance lookup to `leaveType: 'ANNUAL'`, and used `Promise.all` for parallel queries where appropriate.
- Frontend changes add a `DashboardSummary` interface, type `dashboardStats`, implement `OnInit`, add `leaveBalanceDaysRemaining` getter, tighten API typing for `loadDashboardStats`, and update template bindings to use the new getter and direct properties (removing optional chaining for `dashboardStats`).

### Testing
- Ran TypeScript compilation for both backend and frontend with `tsc` and the Angular build with `ng build`, and both succeeded.
- Executed unit tests via `npm test` for the codebase and all tests passed.
- Performed the dashboard API integration check by calling `GET /api/dashboard/summary` during local development and verified the response shape matched the new `DashboardSummary` type.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34ac8338c832baf5c7e23c94ab9eb)