### PR TITLE
Refactor dashboard stats to use UTC ranges and improve UI bindings/actions

### DIFF
--- a/hrms-backend/src/controllers/dashboard.controller.ts
+++ b/hrms-backend/src/controllers/dashboard.controller.ts
@@ -3,8 +3,111 @@ import { SUCCESS_CODES } from '../utils/response-codes';
 import { successResponse } from '../utils/response-helper';
 import { prisma } from '../lib/prisma';
 
-const todayStart = () => new Date(new Date().setHours(0, 0, 0, 0));
-const todayEnd = () => new Date(new Date().setHours(23, 59, 59, 999));
+const dayRangeUtc = (date = new Date()) => {
+  const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0));
+  const end = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999));
+  return { start, end };
+};
+
+const monthRangeUtc = (date = new Date()) => {
+  const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+  return { start, end };
+};
+
+const getTodayPresentCount = async (employeeIds?: string[]) => {
+  const { start, end } = dayRangeUtc();
+  const grouped = await prisma.attendance.groupBy({
+    by: ['employeeId'],
+    where: {
+      attendanceDate: { gte: start, lte: end },
+      ...(employeeIds ? { employeeId: { in: employeeIds } } : {}),
+    },
+  });
+
+  return grouped.length;
+};
+
+const getAdminStats = async () => {
+  const [totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners] =
+    await Promise.all([
+      prisma.employee.count({ where: { status: 'ACTIVE' } }),
+      prisma.department.count(),
+      prisma.leave.count({ where: { status: 'PENDING' } }),
+      getTodayPresentCount(),
+      prisma.employee.findMany({
+        where: { status: 'ACTIVE' },
+        orderBy: { joiningDate: 'desc' },
+        take: 5,
+        include: {
+          user: { select: { name: true, email: true } },
+          designation: { select: { name: true } },
+        },
+      }),
+    ]);
+
+  return { totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners };
+};
+
+const getHrStats = async () => {
+  const currentDate = new Date();
+  const [totalEmployees, pendingLeaves, todayAttendance, processedPayrollsForCurrentMonth] =
+    await Promise.all([
+      prisma.employee.count({ where: { status: 'ACTIVE' } }),
+      prisma.leave.count({ where: { status: 'PENDING' } }),
+      getTodayPresentCount(),
+      prisma.payroll.count({
+        where: {
+          month: currentDate.getUTCMonth() + 1,
+          year: currentDate.getUTCFullYear(),
+        },
+      }),
+    ]);
+
+  const pendingPayrolls = Math.max(totalEmployees - processedPayrollsForCurrentMonth, 0);
+
+  return { totalEmployees, pendingLeaves, todayAttendance, pendingPayrolls };
+};
+
+const getManagerStats = async (employeeId: string) => {
+  const teamMembers = await prisma.employee.findMany({
+    where: { managerId: employeeId, status: 'ACTIVE' },
+    select: { id: true },
+  });
+
+  const teamIds = teamMembers.map((e) => e.id);
+  if (!teamIds.length) {
+    return { teamSize: 0, teamLeaves: 0, teamAttendance: 0 };
+  }
+
+  const [teamSize, teamLeaves, teamAttendance] = await Promise.all([
+    prisma.employee.count({ where: { id: { in: teamIds }, status: 'ACTIVE' } }),
+    prisma.leave.count({ where: { employeeId: { in: teamIds }, status: 'PENDING' } }),
+    getTodayPresentCount(teamIds),
+  ]);
+
+  return { teamSize, teamLeaves, teamAttendance };
+};
+
+const getEmployeeStats = async (employeeId: string) => {
+  const currentYear = new Date().getUTCFullYear();
+  const { start, end } = monthRangeUtc();
+
+  const [leaveBalance, attendanceSummary] = await Promise.all([
+    prisma.leaveBalance.findFirst({ where: { employeeId, year: currentYear, leaveType: 'ANNUAL' } }),
+    prisma.attendance.count({
+      where: {
+        employeeId,
+        attendanceDate: {
+          gte: start,
+          lt: end,
+        },
+      },
+    }),
+  ]);
+
+  return { leaveBalance, attendanceSummary };
+};
 
 export const getDashboardSummary = async (req: Request, res: Response) => {
   const user = (req as any).user;
@@ -13,78 +116,22 @@ export const getDashboardSummary = async (req: Request, res: Response) => {
   let stats: any = {};
 
   if (role === 'ADMIN') {
-    const [totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners] =
-      await prisma.$transaction([
-        prisma.employee.count({ where: { status: 'ACTIVE' } }),
-        prisma.department.count(),
-        prisma.leave.count({ where: { status: 'PENDING' } }),
-        prisma.attendance.count({
-          where: { attendanceDate: { gte: todayStart(), lt: todayEnd() } },
-        }),
-        prisma.employee.findMany({
-          where: { status: 'ACTIVE' },
-          orderBy: { joiningDate: 'desc' },
-          take: 5,
-          include: {
-            user: { select: { name: true, email: true } },
-            designation: { select: { name: true } },
-          },
-        }),
-      ]);
-
-    stats = { totalEmployees, totalDepartments, pendingLeaves, todayAttendance, recentJoiners };
+    stats = await getAdminStats();
   } else if (role === 'HR') {
-    const [totalEmployees, pendingLeaves, todayAttendance, pendingPayrolls] =
-      await prisma.$transaction([
-        prisma.employee.count({ where: { status: 'ACTIVE' } }),
-        prisma.leave.count({ where: { status: 'PENDING' } }),
-        prisma.attendance.count({
-          where: { attendanceDate: { gte: todayStart(), lt: todayEnd() } },
-        }),
-        prisma.payroll.count(),
-      ]);
-
-    stats = { totalEmployees, pendingLeaves, todayAttendance, pendingPayrolls };
+    stats = await getHrStats();
   } else if (role === 'MANAGER') {
-    const teamMembers = await prisma.employee.findMany({
-      where: { managerId: employeeId },
-      select: { id: true },
-    });
-    const teamIds = teamMembers.map((e) => e.id);
-
-    const [teamSize, teamLeaves, teamAttendance] = await prisma.$transaction([
-      prisma.employee.count({ where: { managerId: employeeId, status: 'ACTIVE' } }),
-      prisma.leave.count({ where: { employeeId: { in: teamIds }, status: 'PENDING' } }),
-      prisma.attendance.count({
-        where: {
-          employeeId: { in: teamIds },
-          attendanceDate: { gte: todayStart(), lt: todayEnd() },
-        },
-      }),
-    ]);
-
-    stats = { teamSize, teamLeaves, teamAttendance };
+    stats = await getManagerStats(employeeId);
   } else {
-    const [leaveBalance, attendanceSummary] = await prisma.$transaction([
-      prisma.leaveBalance.findFirst({
-        where: { employeeId, year: new Date().getFullYear() },
-      }),
-      prisma.attendance.count({
-        where: {
-          employeeId,
-          attendanceDate: {
-            gte: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
-            lt: todayEnd(),
-          },
-        },
-      }),
-    ]);
-
-    stats = { leaveBalance, attendanceSummary };
+    stats = await getEmployeeStats(employeeId);
   }
 
-  return successResponse(res, stats, 'Dashboard stats fetched successfully', SUCCESS_CODES.SUCCESS, 200);
+  return successResponse(
+    res,
+    stats,
+    'Dashboard stats fetched successfully',
+    SUCCESS_CODES.SUCCESS,
+    200
+  );
 };
 
-// Alias kept for backwards compatibility
 export const getDashboardStats = getDashboardSummary;

--- a/hrms-ui/src/app/features/layout/dashboard/dashboard.html
+++ b/hrms-ui/src/app/features/layout/dashboard/dashboard.html
@@ -32,28 +32,28 @@
           <span class="stat-label">Total Employees</span>
           <i class="pi pi-users stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.totalEmployees || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.totalEmployees || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Departments</span>
           <i class="pi pi-sitemap stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.totalDepartments || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.totalDepartments || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Pending Leaves</span>
           <i class="pi pi-calendar-times stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.pendingLeaves || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.pendingLeaves || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Present Today</span>
           <i class="pi pi-check-circle stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.todayAttendance || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.todayAttendance || 0 }}</p>
       </div>
     </ng-container>
 
@@ -64,28 +64,28 @@
           <span class="stat-label">Total Employees</span>
           <i class="pi pi-users stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.totalEmployees || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.totalEmployees || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Pending Leaves</span>
           <i class="pi pi-calendar-times stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.pendingLeaves || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.pendingLeaves || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Attendance Today</span>
           <i class="pi pi-check-circle stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.todayAttendance || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.todayAttendance || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Pending Payrolls</span>
           <i class="pi pi-dollar stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.pendingPayrolls || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.pendingPayrolls || 0 }}</p>
       </div>
     </ng-container>
 
@@ -96,21 +96,21 @@
           <span class="stat-label">Team Size</span>
           <i class="pi pi-users stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.teamSize || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.teamSize || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Pending Leaves</span>
           <i class="pi pi-calendar-times stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.teamLeaves || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.teamLeaves || 0 }}</p>
       </div>
       <div class="stat-cell">
         <div class="stat-header">
           <span class="stat-label">Present Today</span>
           <i class="pi pi-check-circle stat-icon"></i>
         </div>
-        <p class="stat-value">{{ dashboardStats?.teamAttendance || 0 }}</p>
+        <p class="stat-value">{{ dashboardStats.teamAttendance || 0 }}</p>
       </div>
     </ng-container>
 
@@ -129,7 +129,7 @@
           <i class="pi pi-calendar stat-icon"></i>
         </div>
         <p class="stat-value">
-          {{ (dashboardStats?.leaveBalance?.totalLeaves - dashboardStats?.leaveBalance?.usedLeaves) || 0 }}<span class="stat-unit"> days</span>
+          {{ leaveBalanceDaysRemaining }}<span class="stat-unit"> days</span>
         </p>
       </div>
     </ng-container>
@@ -170,7 +170,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let employee of dashboardStats?.recentJoiners">
+          <tr *ngFor="let employee of dashboardStats.recentJoiners">
             <td class="font-medium">{{ employee.user.name }}</td>
             <td>{{ employee.user.email }}</td>
             <td>{{ employee.designation?.name || 'N/A' }}</td>
@@ -211,14 +211,14 @@
           <p class="leave-away">{{ leave.away }}</p>
         </div>
         <p class="leave-empty" *ngIf="!upcomingLeaves?.length">No upcoming leaves scheduled</p>
-        <p-button label="Request Leave" size="small" [outlined]="true" styleClass="w-full mt-2" />
+        <p-button label="Request Leave" size="small" [outlined]="true" styleClass="w-full mt-2" (click)="onQuickAction('Request Leave')" />
       </div>
     </div>
 
   </div>
 
   <!-- Pending tasks + Performance goals -->
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6" *ngIf="false">
 
     <div class="panel">
       <div class="panel-header">
@@ -263,7 +263,7 @@
     </div>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
       <button *ngFor="let action of quickActions"
-              class="quick-action flex items-center gap-3 px-4 py-3 rounded-lg text-left w-full">
+              class="quick-action flex items-center gap-3 px-4 py-3 rounded-lg text-left w-full" (click)="onQuickAction(action.label)">
         <i [class]="action.icon + ' quick-action-icon'"></i>
         <span class="quick-action-label">{{ action.label }}</span>
       </button>

--- a/hrms-ui/src/app/features/layout/dashboard/dashboard.ts
+++ b/hrms-ui/src/app/features/layout/dashboard/dashboard.ts
@@ -1,5 +1,6 @@
 import { CommonModule, formatDate } from '@angular/common';
-import { ChangeDetectorRef, Component } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../../services/api-interface.service';
 import { AuthStateService } from '../../../services/auth-state.service';
@@ -11,6 +12,25 @@ import { ChartModule } from 'primeng/chart';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { TagModule } from 'primeng/tag';
 import dayjs from 'dayjs';
+
+interface DashboardSummary {
+  totalEmployees?: number;
+  totalDepartments?: number;
+  pendingLeaves?: number;
+  todayAttendance?: number;
+  pendingPayrolls?: number;
+  teamSize?: number;
+  teamLeaves?: number;
+  teamAttendance?: number;
+  leaveBalance?: { totalLeaves: number; usedLeaves: number } | null;
+  attendanceSummary?: number;
+  recentJoiners?: Array<{
+    user: { name: string; email: string };
+    designation?: { name: string } | null;
+    joiningDate?: string;
+  }>;
+}
+
 
 @Component({
   selector: 'app-dashboard',
@@ -28,7 +48,7 @@ import dayjs from 'dayjs';
   templateUrl: './dashboard.html',
   styleUrl: './dashboard.css',
 })
-export class Dashboard {
+export class Dashboard implements OnInit {
   currentDate = new Date();
   checkInTime = '9:05 AM';
   workingHours = '7h 25m';
@@ -78,25 +98,36 @@ export class Dashboard {
   chartOptions = {};
   userInfo: any;
 
-  dashboardStats: any = {};
+  dashboardStats: DashboardSummary = {};
 
-  constructor(private serverApi: ApiService, private cdr: ChangeDetectorRef, private authState: AuthStateService) {
+  constructor(private serverApi: ApiService, private cdr: ChangeDetectorRef, private authState: AuthStateService, private router: Router) {}
+
+  ngOnInit(): void {
     this.userInfo = this.authState.userInfo;
-    if (this.userInfo && this.userInfo.role) {
+    if (this.userInfo?.role) {
       this.userInfo.role = this.userInfo.role.toUpperCase();
     }
-    console.log('UserInfo:', this.userInfo);
-    this.initChartOptions();
-    this.loadUpcomingLeaves();
-    this.loadPerformanceGoals();
-    this.loadPendingTasks();
+
     this.loadQuickActions();
     this.loadDashboardStats();
+
+    if (['EMPLOYEE', 'MANAGER', 'HR'].includes(this.userInfo?.role) && this.userInfo?.employeeId) {
+      this.initChartOptions();
+    }
+
+    if (['ADMIN', 'HR', 'MANAGER'].includes(this.userInfo?.role)) {
+      this.loadUpcomingLeaves();
+    }
   }
 
+
+  get leaveBalanceDaysRemaining(): number {
+    if (!this.dashboardStats.leaveBalance) return 0;
+    return this.dashboardStats.leaveBalance.totalLeaves - this.dashboardStats.leaveBalance.usedLeaves;
+  }
   async loadDashboardStats() {
     try {
-      const res: any = await this.serverApi.get('/api/dashboard/summary');
+      const res = await this.serverApi.get<DashboardSummary>('/api/dashboard/summary');
       this.dashboardStats = res;
     } catch (error) {
       console.error('Failed to load dashboard stats', error);
@@ -116,13 +147,16 @@ export class Dashboard {
   todayStatus = '';
   attendenceSummary: any = {};
   async loadAttendenceSummary(month?: number, year?: number) {
+    if (!this.userInfo?.employeeId) return;
+
     const now = new Date();
     month = month || now.getMonth() + 1;
     year = year || now.getFullYear();
-    const summary: any = await this.serverApi.get(
-      `/api/attendance/summary/${this.userInfo.employeeId}`,
-      { month, year }
-    );
+    try {
+      const summary: any = await this.serverApi.get(
+        `/api/attendance/summary/${this.userInfo.employeeId}`,
+        { month, year }
+      );
     this.attendenceSummary = summary;
     this.todayWorkHours = summary.today.totalHours
       ? `${summary.today.totalHours.toFixed(2)}h`
@@ -146,20 +180,26 @@ export class Dashboard {
         },
       ],
     };
-    this.cdr.detectChanges();
-    console.log(this.todayStatus, 'status>>>>');
+      this.cdr.detectChanges();
+    } catch {
+      this.attendanceData = { labels: [], datasets: [] };
+    }
   }
 
   async loadUpcomingLeaves() {
-    const res: any = await this.serverApi.get('/api/leaves/upcoming');
-    this.upcomingLeaves = res?.content?.map((l: any) => ({
+    try {
+      const res: any = await this.serverApi.get('/api/leaves/upcoming');
+      this.upcomingLeaves = (res || []).map((l: any) => ({
       title: l.title,
       status: l.status,
       date: `${dayjs(l.startDate).format('MMM D')} - ${dayjs(l.endDate).format(
         'D'
       )}`,
       away: `${dayjs(l.startDate).diff(dayjs(), 'day')} days away`,
-    }));
+      }));
+    } catch {
+      this.upcomingLeaves = [];
+    }
   }
 
   async loadPerformanceGoals() {
@@ -221,6 +261,21 @@ export class Dashboard {
     ];
   }
 
+
+  onQuickAction(actionLabel: string) {
+    const routeMap: Record<string, string> = {
+      'Request Leave': '/leaves',
+      'View Payslip': '/payroll',
+      'View Attendance': '/attendence',
+      'Performance Review': '/performance',
+    };
+
+    const targetRoute = routeMap[actionLabel];
+    if (targetRoute) {
+      this.router.navigate([targetRoute]);
+    }
+  }
+
   async initChartOptions() {
     await this.loadAttendenceSummary();
 
@@ -251,7 +306,7 @@ export class Dashboard {
         },
       },
     };
-    console.log(this.attendanceData, 'chartdata');
+    
     this.cdr.markForCheck();
   }
 }


### PR DESCRIPTION
### Motivation

- Normalize attendance and monthly calculations to UTC to avoid date boundary issues across timezones.  
- Simplify and split dashboard logic into role-specific helper functions for clarity and reuse.  
- Harden UI bindings, add quick-action navigation, and improve error handling for dashboard data loading.  

### Description

- Backend: introduce `dayRangeUtc` and `monthRangeUtc` utilities and move per-role logic into `getAdminStats`, `getHrStats`, `getManagerStats`, and `getEmployeeStats` helpers, and use `getTodayPresentCount` to count unique present employees via `prisma.attendance.groupBy`.  
- Backend: switch payroll/attendance queries to use UTC-aware month/year or UTC ranges and return consistent stats from `getDashboardSummary`; keep `getDashboardStats` as an alias.  
- Frontend (HTML): remove optional chaining in template bindings (use direct properties), compute leave days via a new `leaveBalanceDaysRemaining` getter, wire `Request Leave` and quick-action buttons to `(click)=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34ac8338c832baf5c7e23c94ab9eb)