### PR TITLE
Ensure Users are loaded when Admin 'Users' tab becomes active

### DIFF
--- a/hrms-ui/src/app/features/admin/admin.component.html
+++ b/hrms-ui/src/app/features/admin/admin.component.html
@@ -4,7 +4,7 @@
     <p class="text-sm text-gray-500 mt-1">Manage user access, roles, and system permissions</p>
   </div>
 
-  <p-tabs value="0">
+  <p-tabs [value]="activeTab" (valueChange)="onTabChange($event)">
     <p-tablist>
       <p-tab value="0">
         <i class="pi pi-users mr-2"></i>Users

--- a/hrms-ui/src/app/features/admin/admin.component.ts
+++ b/hrms-ui/src/app/features/admin/admin.component.ts
@@ -43,6 +43,7 @@ export class Admin implements OnInit {
   groupedPermissions: GroupedPermissions = {};
   resources: string[] = [];
 
+  activeTab = '0';
   showRoleDialog = false;
   editingRole: any | null = null;
   roleName = '';
@@ -58,6 +59,16 @@ export class Admin implements OnInit {
     this.loadUsers();
     this.loadRoles();
     this.loadPermissions();
+  }
+
+
+  onTabChange(tabValue: string | number | undefined) {
+    const nextTab = String(tabValue ?? '0');
+    this.activeTab = nextTab;
+
+    if (nextTab === '0' && this.users.length === 0 && !this.usersLoading) {
+      this.loadUsers();
+    }
   }
 
   // ===== Users =====


### PR DESCRIPTION
### Motivation
- The Admin users list could remain empty due to tab initialization/timing, so users should be re-fetched when the Users tab becomes active.

### Description
- Add `activeTab` state and `onTabChange(tabValue: string | number | undefined)` in `hrms-ui/src/app/features/admin/admin.component.ts` and bind `<p-tabs [value]="activeTab" (valueChange)="onTabChange($event)">` in the template so the component reloads users when the Users tab is selected while preserving the existing `ngOnInit` load sequence.

### Testing
- Ran a production build with `cd hrms-ui && npm run build`; an initial TypeScript/template typing error was fixed, however the final build could not complete in this environment due to external Google Fonts inlining returning HTTP 403, and no new TypeScript/template errors remained from the change prior to that network-related failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f352ec4328832b94f5b5f2fb082a3b)