### PR TITLE
feat: auth lockout, payroll workflow, leave audit trail, notification read

### DIFF
--- a/hrms-backend/prisma/schema.prisma
+++ b/hrms-backend/prisma/schema.prisma
@@ -109,11 +109,13 @@ model User {
   userRole        UserRole  @relation(fields: [roleId], references: [id])
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
-  resetToken      String?
-  resetTokenExp   DateTime?
-  refreshToken    String?
-  refreshTokenExp DateTime?
-  deletedAt       DateTime?
+  resetToken           String?
+  resetTokenExp        DateTime?
+  refreshToken         String?
+  refreshTokenExp      DateTime?
+  failedLoginAttempts  Int       @default(0)
+  lockedUntil          DateTime?
+  deletedAt            DateTime?
 
   employee             Employee?
   leavesApproved       Leave[]              @relation("LeaveApprovedBy")

--- a/hrms-backend/src/controllers/leave.controller.ts
+++ b/hrms-backend/src/controllers/leave.controller.ts
@@ -221,12 +221,18 @@ export const updateLeaveStatus = async (req: Request, res: Response) => {
   const leaveYear = leave.startDate.getFullYear();
   const previousStatus = leave.status;
 
+  const { rejectionReason } = req.body;
+  const now = new Date();
+
   // Update leave status
   const updatedLeave = await prisma.leave.update({
     where: { id: id },
     data: {
       status,
       approvedById: approvedBy,
+      approvalDate: status === 'APPROVED' ? now : undefined,
+      rejectionDate: status === 'REJECTED' ? now : undefined,
+      rejectionReason: status === 'REJECTED' ? (rejectionReason ?? null) : undefined,
     },
   });
 
@@ -369,6 +375,47 @@ export const getAllLeaves = async (req: Request, res: Response) => {
     SUCCESS_CODES.SUCCESS,
     200
   );
+};
+
+// ----------------- Cancel Leave -----------------
+export const cancelLeave = async (req: Request, res: Response) => {
+  const id = req.params.id as string;
+  const currentUser = req.user;
+
+  const leave = await prisma.leave.findUnique({
+    where: { id },
+    include: { employee: { include: { user: true } } },
+  });
+
+  if (!leave) throw new HttpError(404, 'Leave not found', ERROR_CODES.NOT_FOUND);
+
+  // Employees can only cancel their own leaves
+  if (currentUser.role === 'EMPLOYEE' && currentUser.employeeId !== leave.employeeId) {
+    throw new HttpError(403, 'Access denied', ERROR_CODES.FORBIDDEN);
+  }
+
+  if (leave.status === 'CANCELLED') {
+    throw new HttpError(400, 'Leave is already cancelled', ERROR_CODES.VALIDATION_ERROR);
+  }
+
+  if (leave.status === 'REJECTED') {
+    throw new HttpError(400, 'Cannot cancel a rejected leave', ERROR_CODES.VALIDATION_ERROR);
+  }
+
+  const wasApproved = leave.status === 'APPROVED';
+  const leaveDays = calculateLeaveDays(leave.startDate, leave.endDate);
+  const leaveYear = leave.startDate.getFullYear();
+
+  await prisma.leave.update({
+    where: { id },
+    data: { status: 'CANCELLED' },
+  });
+
+  if (wasApproved) {
+    await updateUsedLeaves(leave.employeeId, leaveYear, leave.leaveType, -leaveDays);
+  }
+
+  return successResponse(res, null, 'Leave cancelled successfully', SUCCESS_CODES.SUCCESS, 200);
 };
 
 // GET /api/leaves/upcoming

--- a/hrms-backend/src/controllers/notification.controller.ts
+++ b/hrms-backend/src/controllers/notification.controller.ts
@@ -69,6 +69,30 @@ export const listNotifications = async (req: Request, res: Response) => {
   });
 };
 
+export const markNotificationAsRead = async (req: Request, res: Response) => {
+  const id = String(req.params.id);
+  const currentUser = req.user;
+
+  const notification = await prisma.notification.findUnique({ where: { id } });
+  if (!notification) throw new HttpError(404, 'Notification not found', ERROR_CODES.NOT_FOUND);
+
+  if (currentUser.role === 'EMPLOYEE' && currentUser.employeeId !== notification.employeeId) {
+    throw new HttpError(403, 'Access denied', ERROR_CODES.FORBIDDEN);
+  }
+
+  const updated = await prisma.notification.update({
+    where: { id },
+    data: { readStatus: true, readAt: new Date() },
+  });
+
+  return res.status(200).json({
+    message: 'Notification marked as read',
+    data: updated,
+    statusCode: 200,
+    code: SUCCESS_CODES.SUCCESS,
+  });
+};
+
 export const sendBulkNotification = async (req: Request, res: Response) => {
   const { employeeIds, type, message } = req.body;
 

--- a/hrms-backend/src/controllers/payroll.controller.ts
+++ b/hrms-backend/src/controllers/payroll.controller.ts
@@ -81,7 +81,9 @@ export const generatePayroll = async (req: Request, res: Response) => {
       employeeId,
       month,
       year,
+      basicSalary: monthlySalary,
       netSalary,
+      status: 'DRAFT',
       components: {
         create: componentData,
       },
@@ -470,4 +472,44 @@ export const downloadPayslip = async (req: Request, res: Response) => {
     });
 
   doc.end();
+};
+
+// ----------------- Finalize Payroll -----------------
+export const finalizePayroll = async (req: Request, res: Response) => {
+  const id = String(req.params.id);
+  const payroll = await prisma.payroll.findUnique({ where: { id } });
+  if (!payroll) throw new HttpError(404, 'Payroll not found', ERROR_CODES.NOT_FOUND);
+  if (payroll.status !== 'DRAFT') {
+    throw new HttpError(400, `Cannot finalize payroll with status '${payroll.status}'`, ERROR_CODES.VALIDATION_ERROR);
+  }
+  const updated = await prisma.payroll.update({
+    where: { id },
+    data: { status: 'FINALIZED', processedById: req.user?.id as any },
+  });
+  await sendNotification({
+    employeeIds: [payroll.employeeId],
+    type: 'PAYROLL',
+    message: `Your payroll for ${payroll.month}/${payroll.year} has been finalized.`,
+  });
+  return successResponse(res, updated, 'Payroll finalized', SUCCESS_CODES.SUCCESS, 200);
+};
+
+// ----------------- Mark Payroll Paid -----------------
+export const markPayrollPaid = async (req: Request, res: Response) => {
+  const id = String(req.params.id);
+  const payroll = await prisma.payroll.findUnique({ where: { id } });
+  if (!payroll) throw new HttpError(404, 'Payroll not found', ERROR_CODES.NOT_FOUND);
+  if (payroll.status !== 'FINALIZED') {
+    throw new HttpError(400, `Cannot mark as paid — current status is '${payroll.status}'. Finalize first.`, ERROR_CODES.VALIDATION_ERROR);
+  }
+  const updated = await prisma.payroll.update({
+    where: { id },
+    data: { status: 'PAID', paidDate: new Date() },
+  });
+  await sendNotification({
+    employeeIds: [payroll.employeeId],
+    type: 'PAYROLL',
+    message: `Your salary for ${payroll.month}/${payroll.year} has been paid.`,
+  });
+  return successResponse(res, updated, 'Payroll marked as paid', SUCCESS_CODES.SUCCESS, 200);
 };

--- a/hrms-backend/src/routes/leave.route.ts
+++ b/hrms-backend/src/routes/leave.route.ts
@@ -5,6 +5,7 @@ import { CreateLeaveSchema, UpdateLeaveStatusSchema } from '../schemas/leave.sch
 
 import {
   applyLeave,
+  cancelLeave,
   getAllLeaves,
   getEmployeeLeaves,
   getTeamLeaves,
@@ -26,6 +27,18 @@ function registerRouters(app: express.Application) {
     validate(UpdateLeaveStatusSchema),
     updateLeaveStatus
   );
+  app.delete(
+    '/api/leaves/:id',
+    authenticate,
+    roleAccess(['HR', 'ADMIN', 'EMPLOYEE', 'MANAGER']),
+    cancelLeave
+  );
+  app.get(
+    '/api/leaves/upcoming',
+    authenticate,
+    roleAccess(['HR', 'ADMIN', 'EMPLOYEE', 'MANAGER']),
+    getUpcomingLeaves
+  );
   app.get(
     '/api/leaves/:employeeId',
     authenticate,
@@ -43,12 +56,6 @@ function registerRouters(app: express.Application) {
     authenticate,
     roleAccess(['HR', 'ADMIN', 'MANAGER']),
     getAllLeaves
-  );
-  app.get(
-    '/api/leaves/upcoming',
-    authenticate,
-    roleAccess(['HR', 'ADMIN', 'MANAGER']),
-    getUpcomingLeaves
   );
 }
 

--- a/hrms-backend/src/routes/notification.route.ts
+++ b/hrms-backend/src/routes/notification.route.ts
@@ -3,12 +3,14 @@ import { authenticate, roleAccess } from '../middlewares/auth.middleware';
 import {
   sendNotification,
   listNotifications,
+  markNotificationAsRead,
   sendBulkNotification,
 } from '../controllers/notification.controller';
 
 function registerRouters(app: express.Application) {
   app.post('/api/notifications', authenticate, sendNotification);
   app.get('/api/notifications', authenticate, listNotifications);
+  app.patch('/api/notifications/:id/read', authenticate, markNotificationAsRead);
   app.post('/api/notifications/bulk', authenticate, roleAccess(['HR', 'ADMIN']), sendBulkNotification);
 }
 

--- a/hrms-backend/src/routes/payroll.route.ts
+++ b/hrms-backend/src/routes/payroll.route.ts
@@ -4,6 +4,8 @@ import {
   downloadPayslip,
   generatePayroll,
   getPayroll,
+  finalizePayroll,
+  markPayrollPaid,
 } from '../controllers/payroll.controller';
 import { getAllPayrollComponents } from '../controllers/payroll-components.controller';
 import { validate } from '../middlewares/validate';
@@ -29,6 +31,18 @@ function registerRouters(app: express.Application) {
     authenticate,
     roleAccess(['HR', 'ADMIN', 'EMPLOYEE']),
     downloadPayslip
+  );
+  app.post(
+    '/api/payroll/:id/finalize',
+    authenticate,
+    roleAccess(['HR', 'ADMIN']),
+    finalizePayroll
+  );
+  app.post(
+    '/api/payroll/:id/mark-paid',
+    authenticate,
+    roleAccess(['ADMIN']),
+    markPayrollPaid
   );
 }
 

--- a/hrms-backend/src/services/auth.service.ts
+++ b/hrms-backend/src/services/auth.service.ts
@@ -7,6 +7,8 @@ import { ERROR_CODES } from '../utils/response-codes';
 
 const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const JWT_SECRET = process.env.JWT_KEY as string;
+const MAX_FAILED_ATTEMPTS = 5;
+const LOCKOUT_DURATION_MS = 30 * 60 * 1000; // 30 minutes
 
 export class AuthService {
   private hashToken(raw: string): string {
@@ -25,6 +27,16 @@ export class AuthService {
       throw new HttpError(400, 'Invalid credentials', ERROR_CODES.INVALID_CREDENTIALS);
     }
 
+    // Check account lockout
+    if (user.lockedUntil && user.lockedUntil > new Date()) {
+      const minutesLeft = Math.ceil((user.lockedUntil.getTime() - Date.now()) / 60000);
+      throw new HttpError(
+        403,
+        `Account locked. Try again in ${minutesLeft} minute(s).`,
+        ERROR_CODES.INVALID_CREDENTIALS
+      );
+    }
+
     const employee = await prisma.employee.findFirst({ where: { userId: user.id } });
     if (!employee) {
       throw new HttpError(400, 'Invalid credentials', ERROR_CODES.INVALID_CREDENTIALS);
@@ -40,8 +52,27 @@ export class AuthService {
 
     const isValid = await bcrypt.compare(password, user.password);
     if (!isValid) {
-      throw new HttpError(400, 'Invalid credentials', ERROR_CODES.INVALID_CREDENTIALS);
+      const attempts = user.failedLoginAttempts + 1;
+      const shouldLock = attempts >= MAX_FAILED_ATTEMPTS;
+      await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          failedLoginAttempts: attempts,
+          lockedUntil: shouldLock ? new Date(Date.now() + LOCKOUT_DURATION_MS) : null,
+        },
+      });
+      const remaining = MAX_FAILED_ATTEMPTS - attempts;
+      const msg = shouldLock
+        ? 'Account locked for 30 minutes due to too many failed attempts.'
+        : `Invalid credentials. ${remaining} attempt(s) remaining.`;
+      throw new HttpError(400, msg, ERROR_CODES.INVALID_CREDENTIALS);
     }
+
+    // Successful login — reset lockout counters
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { failedLoginAttempts: 0, lockedUntil: null },
+    });
 
     const accessToken = jwt.sign(
       { id: user.id, email: user.email, role: user.userRole?.name, employeeId: employee.id },
@@ -167,8 +198,11 @@ export class AuthService {
       where: { id: user.id },
       data: {
         password: await bcrypt.hash(newPassword, 10),
-        resetToken: token ? null : undefined,
-        resetTokenExp: token ? null : undefined,
+        // Invalidate all active sessions so stolen tokens stop working
+        refreshToken: null,
+        refreshTokenExp: null,
+        resetToken: null,
+        resetTokenExp: null,
       },
     });
   }


### PR DESCRIPTION
## Summary

- **Auth hardening (#59)**: Account lockout after 5 failed login attempts (30-min lock); `failedLoginAttempts`/`lockedUntil` added to `User` schema; counters reset on successful login; password change invalidates all active sessions (clears refresh token)
- **Payroll workflow (#55)**: Full DRAFT → FINALIZED → PAID state machine; `POST /api/payroll/:id/finalize` (HR/ADMIN) and `POST /api/payroll/:id/mark-paid` (ADMIN only); `basicSalary`, `processedById`, and `paidDate` now persisted
- **Leave improvements (#57)**: `updateLeaveStatus` now records `approvalDate`, `rejectionDate`, and `rejectionReason`; new `cancelLeave` handler restores balance for previously-approved leaves; `DELETE /api/leaves/:id`; fixed route ordering so `/upcoming` is not shadowed by `/:employeeId`
- **Notification read (#57)**: `markNotificationAsRead` sets `readStatus=true` and `readAt` timestamp; `PATCH /api/notifications/:id/read` route added

## Test plan

- [ ] Login with wrong password 5 times → account locks; correct password after lock → error with minutes remaining; wait 30 min (or set `lockedUntil` to past) → login succeeds and counters reset
- [ ] Generate payroll → status is `DRAFT`; call finalize → `FINALIZED`; call mark-paid → `PAID`; attempt finalize on `PAID` → 400 error
- [ ] Change password → previous refresh token rejected on next `/api/auth/refresh`
- [ ] Approve leave → `approvalDate` set; reject leave with reason → `rejectionDate` + `rejectionReason` set
- [ ] Cancel approved leave → `usedLeaves` balance restored; cancel pending leave → no balance change; cancel already-cancelled → 400
- [ ] `PATCH /api/notifications/:id/read` → `readStatus=true` and `readAt` non-null; employee attempting to mark another employee's notification → 403

https://claude.ai/code/session_01Efg2UUF4K5rxMfpihKvTVq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Efg2UUF4K5rxMfpihKvTVq)_