### PR TITLE
fix: employee self-access, checkPermission middleware, frontend service tests

### DIFF
--- a/hrms-backend/src/controllers/employee.controller.ts
+++ b/hrms-backend/src/controllers/employee.controller.ts
@@ -29,7 +29,17 @@ export const restoreEmployee = async (req: Request, res: Response) => {
 };
 
 export const getEmployee = async (req: Request, res: Response) => {
-  const employee = await employeeService.findById((req.params.id as string));
+  const id = req.params.id as string;
+  const { role, employeeId } = req.user;
+
+  // Employees can only fetch their own record
+  if (role === 'EMPLOYEE' && employeeId !== id) {
+    const { HttpError } = await import('../utils/http-error');
+    const { ERROR_CODES } = await import('../utils/response-codes');
+    throw new HttpError(403, 'Access denied', ERROR_CODES.FORBIDDEN);
+  }
+
+  const employee = await employeeService.findById(id);
   return successResponse(res, employee, 'Details fetched', SUCCESS_CODES.EMPLOYEE_FETCHED, 200);
 };
 

--- a/hrms-backend/src/middlewares/auth.middleware.ts
+++ b/hrms-backend/src/middlewares/auth.middleware.ts
@@ -71,3 +71,25 @@ export const roleAccess = (allowedRoles: string[]) => {
     next();
   };
 };
+
+/**
+ * Verify the authenticated user has permission for a given module action.
+ * Falls back gracefully if the role isn't in the matrix (treats as no access).
+ */
+export const checkPermission = (module: string, action: string) => {
+  return (req: Request<any>, res: Response, next: NextFunction) => {
+    const { rolePermissions } = require('../utils/permission.utils');
+    const user = req.user;
+
+    if (!user) {
+      return errorResponse(res, 'Unauthorized', ERROR_CODES.UNAUTHORIZED, 401);
+    }
+
+    const rolePerms: string[] = rolePermissions[user.role]?.[module] ?? [];
+    if (!rolePerms.includes(action)) {
+      return errorResponse(res, 'Forbidden: insufficient permissions', ERROR_CODES.FORBIDDEN, 403);
+    }
+
+    next();
+  };
+};

--- a/hrms-backend/src/routes/payroll-component.route.ts
+++ b/hrms-backend/src/routes/payroll-component.route.ts
@@ -6,7 +6,7 @@ import {
   deletePayrollComponent,
   getAllPayrollComponents,
 } from '../controllers/payroll-components.controller';
-import { authenticate, roleAccess } from '../middlewares/auth.middleware';
+import { authenticate, roleAccess, checkPermission } from '../middlewares/auth.middleware';
 
 
 function registerRouters(app: express.Application) {
@@ -32,12 +32,13 @@ function registerRouters(app: express.Application) {
     '/api/payroll/components/:id',
     authenticate,
     roleAccess(['ADMIN', 'HR']),
+    checkPermission('payroll', 'edit'),
     updatePayrollComponent
   );
   app.delete(
     '/api/payroll/components/:id',
     authenticate,
-    roleAccess(['ADMIN', 'HR']),
+    roleAccess(['ADMIN']),
     deletePayrollComponent
   );
 }

--- a/hrms-ui/src/app/guards/auth-guard.spec.ts
+++ b/hrms-ui/src/app/guards/auth-guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { AuthGuard } from './auth-guard';
+import { AuthStateService } from '../services/auth-state.service';
+
+const mockRouter = { navigate: jasmine.createSpy('navigate') };
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let authState: AuthStateService;
+
+  beforeEach(() => {
+    mockRouter.navigate.calls.reset();
+    sessionStorage.clear();
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthGuard,
+        AuthStateService,
+        { provide: Router, useValue: mockRouter },
+      ],
+    });
+
+    guard = TestBed.inject(AuthGuard);
+    authState = TestBed.inject(AuthStateService);
+  });
+
+  afterEach(() => sessionStorage.clear());
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('returns true when user is logged in', () => {
+    authState.set({ id: '1', role: 'EMPLOYEE' });
+    expect(guard.canActivate()).toBeTrue();
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+  });
+
+  it('returns false and navigates to /login when user is not logged in', () => {
+    const result = guard.canActivate();
+    expect(result).toBeFalse();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  it('returns false after user logs out (clear())', () => {
+    authState.set({ id: '1', role: 'EMPLOYEE' });
+    authState.clear();
+    expect(guard.canActivate()).toBeFalse();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/hrms-ui/src/app/pipes/status.pipe.spec.ts
+++ b/hrms-ui/src/app/pipes/status.pipe.spec.ts
@@ -1,0 +1,40 @@
+import { StatusPipe } from './status.pipe';
+
+describe('StatusPipe', () => {
+  const pipe = new StatusPipe();
+
+  it('should create', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  // Leave statuses
+  it('returns "success" for APPROVED', () => {
+    expect(pipe.transform('APPROVED')).toBe('success');
+  });
+
+  it('returns "warn" for PENDING', () => {
+    expect(pipe.transform('PENDING')).toBe('warn');
+  });
+
+  it('returns "danger" for REJECTED', () => {
+    expect(pipe.transform('REJECTED')).toBe('danger');
+  });
+
+  // Employee statuses
+  it('returns "success" for ACTIVE', () => {
+    expect(pipe.transform('ACTIVE')).toBe('success');
+  });
+
+  it('returns "danger" for INACTIVE', () => {
+    expect(pipe.transform('INACTIVE')).toBe('danger');
+  });
+
+  // Unknown
+  it('returns "secondary" for an unknown status string', () => {
+    expect(pipe.transform('UNKNOWN_STATUS')).toBe('secondary');
+  });
+
+  it('returns "secondary" for empty string', () => {
+    expect(pipe.transform('')).toBe('secondary');
+  });
+});

--- a/hrms-ui/src/app/services/api-interface.service.spec.ts
+++ b/hrms-ui/src/app/services/api-interface.service.spec.ts
@@ -1,0 +1,121 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { ApiService } from './api-interface.service';
+import { SpinnerService } from './spinner.service';
+import { environment } from '../../environment/environment';
+
+const mockSpinner = {
+  show: jasmine.createSpy('show'),
+  hide: jasmine.createSpy('hide'),
+};
+
+describe('ApiService', () => {
+  let service: ApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    mockSpinner.show.calls.reset();
+    mockSpinner.hide.calls.reset();
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        ApiService,
+        { provide: SpinnerService, useValue: mockSpinner },
+      ],
+    });
+
+    service = TestBed.inject(ApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  // ------------------------------------------------------------------
+  // GET
+  // ------------------------------------------------------------------
+  describe('get()', () => {
+    it('returns data on success', fakeAsync(async () => {
+      const payload = [{ id: 1 }];
+      const promise = service.get<typeof payload>('/api/test');
+
+      const req = httpMock.expectOne(`${environment.apiUrl}/api/test`);
+      req.flush({ success: true, data: payload, message: 'ok', statusCode: 200 });
+      tick();
+
+      const result = await promise;
+      expect(result).toEqual(payload);
+    }));
+
+    it('shows and hides spinner', fakeAsync(async () => {
+      const promise = service.get('/api/test');
+      httpMock
+        .expectOne(`${environment.apiUrl}/api/test`)
+        .flush({ success: true, data: [], message: 'ok', statusCode: 200 });
+      tick();
+      await promise;
+      expect(mockSpinner.show).toHaveBeenCalledTimes(1);
+      expect(mockSpinner.hide).toHaveBeenCalledTimes(1);
+    }));
+
+    it('throws when success is false', fakeAsync(async () => {
+      const promise = service.get('/api/test');
+      httpMock
+        .expectOne(`${environment.apiUrl}/api/test`)
+        .flush({ success: false, data: null, message: 'Not found', statusCode: 404 });
+      tick();
+      await expectAsync(promise).toBeRejected();
+    }));
+
+    it('skips spinner when spinner=false', fakeAsync(async () => {
+      const promise = service.get('/api/test', undefined, false);
+      httpMock
+        .expectOne(`${environment.apiUrl}/api/test`)
+        .flush({ success: true, data: {}, message: 'ok', statusCode: 200 });
+      tick();
+      await promise;
+      expect(mockSpinner.show).not.toHaveBeenCalled();
+    }));
+  });
+
+  // ------------------------------------------------------------------
+  // POST
+  // ------------------------------------------------------------------
+  describe('post()', () => {
+    it('sends body and returns data', fakeAsync(async () => {
+      const body = { name: 'Test' };
+      const promise = service.post<{ id: number }>('/api/items', body);
+
+      const req = httpMock.expectOne(`${environment.apiUrl}/api/items`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(body);
+      req.flush({ success: true, data: { id: 1 }, message: 'created', statusCode: 200 });
+      tick();
+
+      const result = await promise;
+      expect(result.id).toBe(1);
+    }));
+  });
+
+  // ------------------------------------------------------------------
+  // DELETE
+  // ------------------------------------------------------------------
+  describe('delete()', () => {
+    it('returns null on empty response', fakeAsync(async () => {
+      const promise = service.delete('/api/items/1');
+      httpMock
+        .expectOne(`${environment.apiUrl}/api/items/1`)
+        .flush({ success: true, data: null, message: 'deleted', statusCode: 200 });
+      tick();
+      const result = await promise;
+      expect(result).toBeNull();
+    }));
+  });
+});

--- a/hrms-ui/src/app/services/auth-state.service.spec.ts
+++ b/hrms-ui/src/app/services/auth-state.service.spec.ts
@@ -1,0 +1,92 @@
+import { TestBed } from '@angular/core/testing';
+import { AuthStateService, UserInfo } from './auth-state.service';
+
+const USER: UserInfo = {
+  id: '1',
+  name: 'Alice',
+  email: 'alice@example.com',
+  role: 'EMPLOYEE',
+  employeeId: 'emp-1',
+};
+
+describe('AuthStateService', () => {
+  let service: AuthStateService;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthStateService);
+  });
+
+  afterEach(() => sessionStorage.clear());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('isLoggedIn() returns false when no user is stored', () => {
+    expect(service.isLoggedIn()).toBeFalse();
+  });
+
+  it('set() stores user info and makes isLoggedIn() return true', () => {
+    service.set(USER);
+    expect(service.isLoggedIn()).toBeTrue();
+    expect(service.userInfo?.email).toBe('alice@example.com');
+  });
+
+  it('set() persists to sessionStorage so it survives service reload', () => {
+    service.set(USER);
+    const raw = sessionStorage.getItem('userInfo');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.email).toBe('alice@example.com');
+  });
+
+  it('clear() removes user info and makes isLoggedIn() return false', () => {
+    service.set(USER);
+    service.clear();
+    expect(service.isLoggedIn()).toBeFalse();
+    expect(service.userInfo).toBeNull();
+    expect(sessionStorage.getItem('userInfo')).toBeNull();
+  });
+
+  it('userInfo$ emits null initially and then the user after set()', (done) => {
+    const emitted: (UserInfo | null)[] = [];
+    service.userInfo$.subscribe((v) => {
+      emitted.push(v);
+      if (emitted.length === 2) {
+        expect(emitted[0]).toBeNull();
+        expect(emitted[1]?.email).toBe('alice@example.com');
+        done();
+      }
+    });
+    service.set(USER);
+  });
+
+  it('userInfo$ emits null after clear()', (done) => {
+    service.set(USER);
+    const emitted: (UserInfo | null)[] = [];
+    service.userInfo$.subscribe((v) => {
+      emitted.push(v);
+      if (emitted.length === 2) {
+        expect(emitted[1]).toBeNull();
+        done();
+      }
+    });
+    service.clear();
+  });
+
+  it('loads existing sessionStorage data on construction', () => {
+    sessionStorage.setItem('userInfo', JSON.stringify(USER));
+    // Re-create service to trigger constructor load
+    const svc2 = new AuthStateService();
+    expect(svc2.isLoggedIn()).toBeTrue();
+    expect(svc2.userInfo?.role).toBe('EMPLOYEE');
+  });
+
+  it('handles corrupt sessionStorage JSON gracefully', () => {
+    sessionStorage.setItem('userInfo', 'not-valid-json');
+    const svc2 = new AuthStateService();
+    expect(svc2.isLoggedIn()).toBeFalse();
+  });
+});

--- a/hrms-ui/src/app/services/notification.service.spec.ts
+++ b/hrms-ui/src/app/services/notification.service.spec.ts
@@ -1,0 +1,102 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { NotificationService, Notification } from './notification.service';
+import { ApiService } from './api-interface.service';
+import { MessageService } from 'primeng/api';
+
+const mockApiService = {
+  get: jasmine.createSpy('get').and.returnValue(Promise.resolve([])),
+  patch: jasmine.createSpy('patch').and.returnValue(Promise.resolve({})),
+};
+
+const mockMessageService = {
+  add: jasmine.createSpy('add'),
+};
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    mockApiService.get.calls.reset();
+    mockApiService.patch.calls.reset();
+    mockMessageService.add.calls.reset();
+
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationService,
+        { provide: ApiService, useValue: mockApiService },
+        { provide: MessageService, useValue: mockMessageService },
+      ],
+    });
+    service = TestBed.inject(NotificationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('notifications$ starts as empty array', (done) => {
+    service.notifications$.subscribe((n) => {
+      expect(n).toEqual([]);
+      done();
+    });
+  });
+
+  describe('fetchNotifications', () => {
+    it('calls GET with the correct URL and updates notifications$', fakeAsync(() => {
+      const items: Notification[] = [
+        { id: 1, employeeId: 'emp-1', type: 'SYSTEM', message: 'Hello' },
+      ];
+      mockApiService.get.and.returnValue(Promise.resolve(items));
+
+      let result: Notification[] = [];
+      service.notifications$.subscribe((n) => (result = n));
+
+      service.fetchNotifications('emp-1');
+      tick();
+
+      expect(mockApiService.get).toHaveBeenCalledWith(
+        '/api/notifications?employeeId=emp-1'
+      );
+      expect(result).toEqual(items);
+    }));
+  });
+
+  describe('markAsRead', () => {
+    it('calls PATCH with correct URL', fakeAsync(() => {
+      mockApiService.patch.and.returnValue(Promise.resolve({}));
+      service.markAsRead(42);
+      tick();
+      expect(mockApiService.patch).toHaveBeenCalledWith(
+        '/api/notifications/42/read',
+        {}
+      );
+    }));
+
+    it('updates local read state on success', fakeAsync(() => {
+      const notifications: Notification[] = [
+        { id: 1, employeeId: 'emp-1', type: 'SYSTEM', message: 'A', read: false },
+        { id: 2, employeeId: 'emp-1', type: 'SYSTEM', message: 'B', read: false },
+      ];
+      mockApiService.get.and.returnValue(Promise.resolve(notifications));
+      service.fetchNotifications('emp-1');
+      tick();
+
+      mockApiService.patch.and.returnValue(Promise.resolve({}));
+      service.markAsRead(1);
+      tick();
+
+      let result: Notification[] = [];
+      service.notifications$.subscribe((n) => (result = n));
+      expect(result.find((n) => n.id === 1)?.read).toBeTrue();
+      expect(result.find((n) => n.id === 2)?.read).toBeFalse();
+    }));
+
+    it('silently ignores PATCH errors without throwing', fakeAsync(() => {
+      mockApiService.patch.and.returnValue(Promise.reject(new Error('network')));
+      expect(() => {
+        service.markAsRead(99);
+        tick();
+      }).not.toThrow();
+    }));
+  });
+});

--- a/hrms-ui/src/app/services/validation.service.spec.ts
+++ b/hrms-ui/src/app/services/validation.service.spec.ts
@@ -1,0 +1,80 @@
+import { TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup } from '@angular/forms';
+import { ValidationService } from './validation.service';
+
+describe('ValidationService', () => {
+  let service: ValidationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ValidationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  // ------------------------------------------------------------------
+  // passwordValidator
+  // ------------------------------------------------------------------
+  describe('passwordValidator', () => {
+    it('returns null for a valid password (mixed case + digit + ≥8 chars)', () => {
+      expect(service.passwordValidator(new FormControl('StrongPass1'))).toBeNull();
+    });
+
+    it('returns null for an empty value (required is handled separately)', () => {
+      expect(service.passwordValidator(new FormControl(''))).toBeNull();
+    });
+
+    it('returns error for password with no uppercase', () => {
+      expect(service.passwordValidator(new FormControl('weakpass1'))).toEqual({ passwordStrength: true });
+    });
+
+    it('returns error for password with no lowercase', () => {
+      expect(service.passwordValidator(new FormControl('STRONGPASS1'))).toEqual({ passwordStrength: true });
+    });
+
+    it('returns error for password with no digit', () => {
+      expect(service.passwordValidator(new FormControl('StrongPassword'))).toEqual({ passwordStrength: true });
+    });
+
+    it('returns error for password shorter than 8 chars', () => {
+      expect(service.passwordValidator(new FormControl('Sh0rt'))).toEqual({ passwordStrength: true });
+    });
+
+    it('accepts exactly 8-character valid password', () => {
+      expect(service.passwordValidator(new FormControl('Valid1Pa'))).toBeNull();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // matchPasswords
+  // ------------------------------------------------------------------
+  describe('matchPasswords', () => {
+    const makeGroup = (newPassword: string, confirmPassword: string) =>
+      new FormGroup({
+        newPassword: new FormControl(newPassword),
+        confirmPassword: new FormControl(confirmPassword),
+      });
+
+    it('returns null when passwords match', () => {
+      expect(service.matchPasswords(makeGroup('Match1Pass', 'Match1Pass'))).toBeNull();
+    });
+
+    it('returns passwordMismatch error when passwords differ', () => {
+      const result = service.matchPasswords(makeGroup('OnePass1', 'TwoPass2'));
+      expect(result).toEqual({ passwordMismatch: true });
+    });
+
+    it('sets confirmPassword field error when passwords differ', () => {
+      const group = makeGroup('OnePass1', 'TwoPass2');
+      service.matchPasswords(group);
+      expect(group.get('confirmPassword')?.errors).toEqual({ passwordMismatch: true });
+    });
+
+    it('handles missing controls gracefully (returns null)', () => {
+      const group = new FormGroup({ newPassword: new FormControl('only') });
+      expect(service.matchPasswords(group)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Employee self-access (#49)**: `GET /api/employees/:id` now returns 403 if an EMPLOYEE requests a record that isn't their own, preventing salary/personal data leakage
- **`checkPermission` middleware (#49)**: wires `permission.utils.ts` matrix into Express; applied to `PUT /api/payroll/components/:id` — HR is blocked from editing payroll components (only ADMIN has `payroll.edit`); `DELETE` tightened to ADMIN-only
- **AuthStateService spec (#62)**: 8 tests — `set`/`clear`/`isLoggedIn`, sessionStorage persistence and hydration on construction, `userInfo$` Observable emissions, corrupt JSON graceful handling
- **ValidationService spec (#62)**: 10 tests — `passwordValidator` (valid, missing uppercase/lowercase/digit, too short, exact 8-char boundary), `matchPasswords` (match, mismatch, field error propagation, missing control)

## Test plan

- [ ] As EMPLOYEE, `GET /api/employees/:own-id>` → 200; `GET /api/employees/<other-id>` → 403
- [ ] As HR, `PUT /api/payroll/components/:id` → 403 (HR lacks `payroll.edit`); as ADMIN → 200
- [ ] As HR, `DELETE /api/payroll/components/:id` → 403; as ADMIN → 200
- [ ] Frontend: `npm test` in `hrms-ui/` — 18 new assertions pass

https://claude.ai/code/session_01Efg2UUF4K5rxMfpihKvTVq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Efg2UUF4K5rxMfpihKvTVq)_