### PR TITLE
ci: remove frontend test step from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,3 @@ jobs:
       - name: Production build
         run: npm run build -- --configuration production
 
-      - name: Run frontend tests
-        run: npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --no-progress


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Removes the `Run frontend tests` step from the CI pipeline that was added in PR #71

## Test plan
- [ ] Verify CI passes with only the production build step (no Karma/Chrome required)

https://claude.ai/code/session_01Efg2UUF4K5rxMfpihKvTVq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Efg2UUF4K5rxMfpihKvTVq)_