### PR TITLE
fix(#49): enforce permission matrix across routes and add manager team scoping

### DIFF
--- a/hrms-backend/src/controllers/leave.controller.ts
+++ b/hrms-backend/src/controllers/leave.controller.ts
@@ -206,6 +206,11 @@ export const updateLeaveStatus = async (req: Request, res: Response) => {
     throw new HttpError(404, 'Leave not found', ERROR_CODES.NOT_FOUND);
   }
 
+  // MANAGER can only approve/reject leaves of their direct reports
+  if (req.user.role === 'MANAGER' && leave.employee.managerId !== req.user.employeeId) {
+    throw new HttpError(403, 'Forbidden: you can only manage leaves of your direct reports', ERROR_CODES.FORBIDDEN);
+  }
+
   const approvedByUser = await prisma.user.findUnique({
     where: {
       id: approvedBy,

--- a/hrms-backend/src/routes/admin.route.ts
+++ b/hrms-backend/src/routes/admin.route.ts
@@ -7,18 +7,18 @@ import {
   updateRole,
 } from '../controllers/roles.controller';
 import { getPermissions } from '../controllers/permissions.controller';
-import { authenticate } from '../middlewares/auth.middleware';
+import { authenticate, roleAccess } from '../middlewares/auth.middleware';
 
 function registerRouters(app: express.Application) {
   // Role Routes
-  app.get('/api/roles', authenticate, getRoles);
-  app.get('/api/roles/:id', authenticate, getRoleById);
-  app.post('/api/roles', authenticate, createRole);
-  app.put('/api/roles/:id', authenticate, updateRole);
-  app.delete('/api/roles/:id', authenticate, deleteRole);
+  app.get('/api/roles', authenticate, roleAccess(['ADMIN']), getRoles);
+  app.get('/api/roles/:id', authenticate, roleAccess(['ADMIN']), getRoleById);
+  app.post('/api/roles', authenticate, roleAccess(['ADMIN']), createRole);
+  app.put('/api/roles/:id', authenticate, roleAccess(['ADMIN']), updateRole);
+  app.delete('/api/roles/:id', authenticate, roleAccess(['ADMIN']), deleteRole);
 
   // Permission Routes
-  app.get('/api/permissions', authenticate, getPermissions);
+  app.get('/api/permissions', authenticate, roleAccess(['ADMIN']), getPermissions);
 }
 
 export default registerRouters;

--- a/hrms-backend/src/routes/leave.route.ts
+++ b/hrms-backend/src/routes/leave.route.ts
@@ -23,7 +23,7 @@ function registerRouters(app: express.Application) {
   app.patch(
     '/api/leaves/:id/status',
     authenticate,
-    roleAccess(['HR', 'ADMIN', 'EMPLOYEE', 'MANAGER']),
+    roleAccess(['HR', 'ADMIN', 'MANAGER']),
     validate(UpdateLeaveStatusSchema),
     updateLeaveStatus
   );

--- a/hrms-backend/src/routes/payroll-component.route.ts
+++ b/hrms-backend/src/routes/payroll-component.route.ts
@@ -25,7 +25,7 @@ function registerRouters(app: express.Application) {
   app.post(
     '/api/payroll/components',
     authenticate,
-    roleAccess(['ADMIN', 'HR']),
+    roleAccess(['ADMIN']),
     createPayrollComponent
   );
   app.put(

--- a/hrms-backend/src/routes/payroll.route.ts
+++ b/hrms-backend/src/routes/payroll.route.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { authenticate, roleAccess } from '../middlewares/auth.middleware';
+import { authenticate, roleAccess, checkPermission } from '../middlewares/auth.middleware';
 import {
   downloadPayslip,
   generatePayroll,
@@ -30,6 +30,7 @@ function registerRouters(app: express.Application) {
     '/api/payroll',
     authenticate,
     roleAccess(['HR', 'ADMIN']),
+    checkPermission('payroll', 'generate'),
     validate(GeneratePayrollSchema),
     generatePayroll
   );
@@ -37,6 +38,7 @@ function registerRouters(app: express.Application) {
     '/api/payroll/batch',
     authenticate,
     roleAccess(['HR', 'ADMIN']),
+    checkPermission('payroll', 'generate'),
     generateBatchPayroll
   );
   app.get(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #49 — the `rolePermissions` matrix was defined in `permission.utils.ts` but largely unenforced. This PR wires it in across the key routes and adds missing access controls.

### Changes

- **`admin.route.ts`** — Added `roleAccess(['ADMIN'])` to all role and permission endpoints. Previously any authenticated user could create/update/delete roles.
- **`payroll-component.route.ts`** — Restricted `POST /api/payroll/components` to `ADMIN` only. HR could create payroll components but shouldn't (edit was already blocked via `checkPermission('payroll', 'edit')`).
- **`leave.route.ts`** — Removed `EMPLOYEE` from `PATCH /api/leaves/:id/status`. Employees cannot approve or reject leave requests.
- **`leave.controller.ts`** — Added MANAGER team scoping to `updateLeaveStatus`: a MANAGER can only approve/reject leaves for their direct reports (`leave.employee.managerId === req.user.employeeId`).
- **`payroll.route.ts`** — Added `checkPermission('payroll', 'generate')` to `POST /api/payroll` and `POST /api/payroll/batch` so the permission matrix is enforced in addition to role checks.

## Test plan

- [ ] ADMIN can create/update/delete roles; HR/MANAGER/EMPLOYEE get 403
- [ ] Only ADMIN can create payroll components; HR gets 403
- [ ] EMPLOYEE cannot call `PATCH /api/leaves/:id/status` (gets 403 from roleAccess)
- [ ] MANAGER can approve leaves only for their direct reports; attempting to approve another team's leave returns 403
- [ ] HR can still generate payroll; MANAGER/EMPLOYEE cannot

https://claude.ai/code/session_01No93FYzeAL1Av6vNYeMsZj
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01No93FYzeAL1Av6vNYeMsZj)_